### PR TITLE
Refresh the sample app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath "com.android.tools:r8:$r8Version"
         classpath "com.android.tools.build:gradle:$gradlePluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.38.1'
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
         classpath "io.github.gradle-nexus:publish-plugin:$gradleNexusVersion"
     }
 }

--- a/library-test/build.gradle
+++ b/library-test/build.gradle
@@ -14,7 +14,6 @@ apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 android {
     kotlinOptions.useIR = true
     compileSdkVersion androidCompileSdkVersion
-    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         minSdkVersion androidMinSdkVersion

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,6 @@ apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 android {
     kotlinOptions.useIR = true
     compileSdkVersion androidCompileSdkVersion
-    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         minSdkVersion androidMinSdkVersion

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,7 +8,6 @@ plugins {
 def composeVersion = '1.0.5'
 android {
     compileSdk androidCompileSdkVersion
-    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "com.alexstyl.contactstore.sample"
@@ -17,7 +16,6 @@ android {
         versionCode libraryVersionCode
         versionName libraryVersionName
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary true
         }
@@ -53,14 +51,14 @@ dependencies {
     implementation project(':library')
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation 'com.google.android.material:material:1.4.0'
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-compiler:2.38.1"
-    implementation "androidx.hilt:hilt-navigation-compose:1.0.0-beta01"
-    implementation "androidx.navigation:navigation-compose:2.4.0-beta02"
+    implementation "com.google.dagger:hilt-android:$hiltVersion"
+    kapt "com.google.dagger:hilt-compiler:$hiltVersion"
+    implementation "androidx.hilt:hilt-navigation-compose:1.0.0-rc01"
+    implementation "androidx.navigation:navigation-compose:2.4.0-rc01"
     implementation("io.coil-kt:coil-compose:1.3.2")
     implementation "androidx.compose.ui:ui:$composeVersion"
     implementation "androidx.compose.material:material:$composeVersion"
     implementation "androidx.compose.ui:ui-tooling:$composeVersion"
-    implementation "androidx.activity:activity-compose:$composeVersion"
+    implementation "androidx.activity:activity-compose:1.4.0"
     implementation "com.google.accompanist:accompanist-systemuicontroller:0.18.0"
 }

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ContactDetailsActivity.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ContactDetailsActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import coil.transform.CircleCropTransformation
 import com.alexstyl.contactstore.Contact
@@ -44,7 +45,7 @@ import com.alexstyl.contactstore.ContactColumn.LinkedAccountValues
 import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactStore
 import com.alexstyl.contactstore.imageUri
-import com.alexstyl.contactstore.sample.ui.setupSystemUi
+import com.alexstyl.contactstore.sample.ui.SetupSystemUi
 import com.alexstyl.contactstore.sample.ui.theme.SampleAppTheme
 import com.alexstyl.contactstore.standardColumns
 import dagger.hilt.android.AndroidEntryPoint
@@ -52,6 +53,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
+@ExperimentalCoilApi
 @AndroidEntryPoint
 class ContactDetailsActivity : ComponentActivity() {
 
@@ -97,7 +99,7 @@ class ContactDetailsActivity : ComponentActivity() {
         onUpClick: () -> Unit = {}
     ) {
         SampleAppTheme {
-            setupSystemUi()
+            SetupSystemUi()
             Scaffold {
                 Box {
                     LazyColumn(
@@ -165,7 +167,7 @@ class ContactDetailsActivity : ComponentActivity() {
                                     label = value.summary,
                                     value = value.detail,
                                     onClick = {
-                                        kotlin.runCatching {
+                                        runCatching {
                                             val intent = Intent(
                                                 Intent.ACTION_VIEW, ContentUris.withAppendedId(
                                                     ContactsContract.Data.CONTENT_URI, value.id

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListActivity.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListActivity.kt
@@ -2,9 +2,7 @@ package com.alexstyl.contactstore.sample
 
 import android.Manifest
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.ContactsContract
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -12,42 +10,29 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Card
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import coil.transform.CircleCropTransformation
 import com.alexstyl.contactstore.Contact
 import com.alexstyl.contactstore.imageUri
 import com.alexstyl.contactstore.sample.ContactDetailsActivity.Companion.EXTRA_CONTACT_ID
-import com.alexstyl.contactstore.sample.ContactListState.Loaded
-import com.alexstyl.contactstore.sample.ContactListState.Loading
-import com.alexstyl.contactstore.sample.ContactListState.PermissionRequired
-import com.alexstyl.contactstore.sample.ui.setupSystemUi
+import com.alexstyl.contactstore.sample.ContactListState.*
+import com.alexstyl.contactstore.sample.ui.SetupSystemUi
 import com.alexstyl.contactstore.sample.ui.theme.SampleAppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
+@ExperimentalCoilApi
 @AndroidEntryPoint
 class ContactListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -75,7 +60,7 @@ class ContactListActivity : ComponentActivity() {
             color = MaterialTheme.colors.background,
             modifier = Modifier.fillMaxSize()
         ) {
-            setupSystemUi()
+            SetupSystemUi()
 
             val requestPermission =
                 rememberLauncherForActivityResult(RequestPermission()) { isGranted ->
@@ -125,6 +110,7 @@ fun LoadingScreen() {
     }
 }
 
+@ExperimentalCoilApi
 @Composable
 fun ContactList(contacts: List<Contact>, onContactClick: (Contact) -> Unit) {
     LazyColumn(
@@ -157,6 +143,7 @@ fun ContactList(contacts: List<Contact>, onContactClick: (Contact) -> Unit) {
     }
 }
 
+@ExperimentalCoilApi
 @Composable
 fun ContactRow(contact: Contact, onClick: (Contact) -> Unit) {
     Card(

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListViewModel.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListViewModel.kt
@@ -2,6 +2,7 @@ package com.alexstyl.contactstore.sample
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alexstyl.contactstore.ContactPredicate
 import com.alexstyl.contactstore.ContactStore
 import com.alexstyl.contactstore.sample.ContactListState.Loaded
 import com.alexstyl.contactstore.sample.ContactListState.PermissionRequired
@@ -26,7 +27,7 @@ class ContactListViewModel @Inject constructor(
             reloadContacts.collect {
                 contactStore.fetchContacts()
                     .collect {
-                        state.emit(Loaded(it))
+                        state.emit(Loaded(it.sortedByDescending { contact -> contact.isStarred }))
                     }
             }
         }

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListViewModel.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ContactListViewModel.kt
@@ -27,7 +27,7 @@ class ContactListViewModel @Inject constructor(
             reloadContacts.collect {
                 contactStore.fetchContacts()
                     .collect {
-                        state.emit(Loaded(it.sortedByDescending { contact -> contact.isStarred }))
+                        state.emit(Loaded(it))
                     }
             }
         }

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ui/setupSystemUi.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ui/setupSystemUi.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Composable
-fun setupSystemUi() {
+fun SetupSystemUi() {
     val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -12,9 +12,9 @@ ext {
 
     r8Version = '3.0.73'
     gradlePluginVersion = '7.0.4'
-    androidBuildToolsVersion = '30.0.2'
     kotlinVersion = '1.5.31'
     coroutinesVersion = '1.5.2'
+    hiltVersion = '2.40.5'
     junitVersion = '4.13.2'
     testRunnerVersion = '1.4.0'
     testRulesVersion = '1.4.0'


### PR DESCRIPTION
- updated dependencies
- removed `buildToolsVersion` - the project automatically uses a default version of the build tools that the plugin specifies. [docs](https://developer.android.com/studio/releases/build-tools)
- renamed compose function to follow compose naming convention
- removed lint warnings - add an experimental annotation for Coil
- sorted contacts in descending order by "isStarred" - to imitate the original Google contacts application
- removed test runner - sample app does not have any tests