### PR TITLE
Introduce Github Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,34 @@
+name: Run PR checks
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1.0.4
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Run instrumented tests using emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 29
+          script: ./gradlew connectedAndroidtest


### PR DESCRIPTION
# This change aims to introduce Github Action in the project - issue: #29 

Requirements:
- [X]  Have all unit tests and Android tests run when someone opens a PR.
- [X] If any of the tests fail, then the PR should be blocked.
- [X] Document is a way (i.e. on your PR) how this automation works.


## How it works?
- Runs on every pull request on the target branch: "main"

Steps are: 
- Checkout
- Gradle wrapper validation - From the security perspective it is always good to check if the binary we download is trustful, in that case, it checks the checksum
- Grants execution permission to Gradle
- Runs all unit tests in all modules - `./gradlew test`
- Sets up an emulator with the API level 29 and runs all instrumented tests in all modules against the emulator - `./gradlew connectedAndroidtest`

## How to set up branch protection and mergeability of PR?
- Enable status checks in repository settings, [Github docs with images](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule).
- Settings -> Actions tab -> "allow all actions".  "Allow select actions" is much better but a bit hassle to update every time. Opt-in at your convenience.
- Settings -> Actions tab -> "Read repository contents permission", feels safer. It will protect the project if some contributors accidentally misuse any step from the action.


## Future suggestions:
- add lint checks
- OWASP dependency check to check all the dependencies against the common vulnerabilities