### PR TITLE
Add builder version of mutableCopy

### DIFF
--- a/library/src/androidTest/java/com/alexstyl/contactstore/AddValuesToExistingContactContactStoreTest.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/AddValuesToExistingContactContactStoreTest.kt
@@ -1,7 +1,16 @@
 package com.alexstyl.contactstore
 
-import com.alexstyl.contactstore.ContactColumn.*
+import com.alexstyl.contactstore.ContactColumn.Events
+import com.alexstyl.contactstore.ContactColumn.ImAddresses
+import com.alexstyl.contactstore.ContactColumn.Mails
+import com.alexstyl.contactstore.ContactColumn.Names
 import com.alexstyl.contactstore.ContactColumn.Note
+import com.alexstyl.contactstore.ContactColumn.Organization
+import com.alexstyl.contactstore.ContactColumn.Phones
+import com.alexstyl.contactstore.ContactColumn.PostalAddresses
+import com.alexstyl.contactstore.ContactColumn.Relations
+import com.alexstyl.contactstore.ContactColumn.SipAddresses
+import com.alexstyl.contactstore.ContactColumn.WebAddresses
 import com.alexstyl.contactstore.Label.RelationManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -17,7 +26,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val updated = contact.mutableCopy().apply {
+        val updated = contact.mutableCopy {
             prefix = "A."
             firstName = "Paolo"
             middleName = "M."
@@ -38,7 +47,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             phones.add(
                 LabeledValue(
                     PhoneNumber("555"),
@@ -61,7 +70,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             mails.add(
                 LabeledValue(
                     MailAddress("555@mail.com"),
@@ -84,7 +93,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             events.add(
                 LabeledValue(
                     EventDate(1, 1, 2020),
@@ -107,7 +116,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             postalAddresses.add(
                 LabeledValue(
                     PostalAddress("SomeStreet 35"),
@@ -130,7 +139,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             webAddresses.add(
                 LabeledValue(
                     WebAddress("https://web/address"),
@@ -172,7 +181,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             note = Note("To infinity and beyond!")
         }
 
@@ -190,7 +199,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             imAddresses.add(
                 LabeledValue(
                     ImAddress("address", protocol = "protocol"),
@@ -213,7 +222,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             relations.add(
                 LabeledValue(
                     Relation(name = "Maria"),
@@ -235,7 +244,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
             lastName = "Melendez"
         }
 
-        val expected = contact.mutableCopy().apply {
+        val expected = contact.mutableCopy {
             sipAddresses.add(
                 LabeledValue(
                     SipAddress("123"),

--- a/library/src/main/java/com/alexstyl/contactstore/Contact.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/Contact.kt
@@ -180,6 +180,16 @@ public fun Contact.containsLinkedAccountColumns(): Boolean {
  * Modifying the properties of the contact will not affect the stored contact of the device.
  * See [ContactStore] to learn how to persist your changes.
  */
+public fun Contact.mutableCopy(builder: MutableContact.() -> Unit): MutableContact {
+    return mutableCopy().apply(builder)
+}
+
+/**
+ * Creates a copy of the Contact that can have its properties modified.
+ *
+ * Modifying the properties of the contact will not affect the stored contact of the device.
+ * See [ContactStore] to learn how to persist your changes.
+ */
 public fun Contact.mutableCopy(): MutableContact {
     return MutableContact(
         contactId = contactId,
@@ -205,7 +215,7 @@ public fun Contact.mutableCopy(): MutableContact {
         else
             mutableListOf(),
         imAddresses = if (containsColumn(ImAddresses)) imAddresses.toMutableList() else mutableListOf(),
-        relations = if(containsColumn(Relations)) relations.toMutableList() else mutableListOf(),
+        relations = if (containsColumn(Relations)) relations.toMutableList() else mutableListOf(),
         note = if (containsColumn(Note)) note else null,
         columns = columns,
         middleName = if (containsColumn(Names)) middleName else null,


### PR DESCRIPTION
Example of usage: 

```kotlin
        val newContact = contact.mutableCopy {
            mails.add(
                LabeledValue(
                    MailAddress("555@mail.com"),
                    Label.LocationHome
                )
            )
        }
```