### PR TITLE
Introduce DisplayNameStyle in ContactStore#fetchContacts

### DIFF
--- a/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
+++ b/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
@@ -6,6 +6,7 @@ import com.alexstyl.contactstore.ContactColumn
 import com.alexstyl.contactstore.ContactOperation
 import com.alexstyl.contactstore.ContactPredicate
 import com.alexstyl.contactstore.ContactStore
+import com.alexstyl.contactstore.DisplayNameStyle
 import com.alexstyl.contactstore.ExperimentalContactStoreApi
 import com.alexstyl.contactstore.MutableContact
 import com.alexstyl.contactstore.PartialContact
@@ -168,7 +169,8 @@ public class TestContactStore(
 
     override fun fetchContacts(
         predicate: ContactPredicate?,
-        columnsToFetch: List<ContactColumn>
+        columnsToFetch: List<ContactColumn>,
+        displayNameStyle: DisplayNameStyle
     ): Flow<List<Contact>> {
         return snapshot
             .map { contacts ->

--- a/library/src/main/java/com/alexstyl/contactstore/AndroidContactStore.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/AndroidContactStore.kt
@@ -2,7 +2,9 @@ package com.alexstyl.contactstore
 
 import android.content.ContentResolver
 import android.provider.ContactsContract
-import com.alexstyl.contactstore.ContactOperation.*
+import com.alexstyl.contactstore.ContactOperation.Delete
+import com.alexstyl.contactstore.ContactOperation.Insert
+import com.alexstyl.contactstore.ContactOperation.Update
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -28,8 +30,9 @@ internal class AndroidContactStore(
 
     override fun fetchContacts(
         predicate: ContactPredicate?,
-        columnsToFetch: List<ContactColumn>
+        columnsToFetch: List<ContactColumn>,
+        displayNameStyle: DisplayNameStyle
     ): Flow<List<Contact>> {
-        return contactQueries.queryContacts(predicate, columnsToFetch)
+        return contactQueries.queryContacts(predicate, columnsToFetch, displayNameStyle)
     }
 }

--- a/library/src/main/java/com/alexstyl/contactstore/ContactStore.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactStore.kt
@@ -28,10 +28,12 @@ public interface ContactStore {
      *
      * @param predicate The conditions that a contact need to meet in order to be fetched
      * @param columnsToFetch The columns of the contact you need to be fetched
+     * @param displayNameStyle The preferred style for the [Contact.displayName] to be returned. The fetched contacts' sorting order will match this option.
      */
     public fun fetchContacts(
         predicate: ContactPredicate? = null,
-        columnsToFetch: List<ContactColumn> = emptyList()
+        columnsToFetch: List<ContactColumn> = emptyList(),
+        displayNameStyle: DisplayNameStyle = DisplayNameStyle.Primary
     ): Flow<List<Contact>>
 
     public companion object {

--- a/library/src/main/java/com/alexstyl/contactstore/DisplayNameStyle.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/DisplayNameStyle.kt
@@ -1,0 +1,15 @@
+package com.alexstyl.contactstore
+
+public enum class DisplayNameStyle {
+    /**
+     * The standard text shown as the contact's display name, based on the best available information for the contact (for example, it might be the email address if the name
+     * is not available).
+     */
+    Primary,
+
+    /**
+     * An alternative representation of the display name, such as "family name first" instead of "given name first" for Western names.
+     * If an alternative is not available, the values should be the same as [Primary].
+     */
+    Alternative
+}

--- a/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
@@ -53,7 +53,8 @@ internal class ExistingContactOperationsFactory(
     private suspend fun updateSuspend(contact: MutableContact): List<ContentProviderOperation> {
         val existingContact = contactQueries.queryContacts(
             predicate = ContactPredicate.ContactLookup(inContactIds = listOf(contact.contactId)),
-            columnsToFetch = contact.columns
+            columnsToFetch = contact.columns,
+            displayNameStyle = DisplayNameStyle.Primary
         ).first().firstOrNull() ?: return emptyList()
         return updatesNames(contact) +
                 replacePhoto(contact) +

--- a/library/src/test/java/com/alexstyl/contactstore/ContactStoreDSLKtTest.kt
+++ b/library/src/test/java/com/alexstyl/contactstore/ContactStoreDSLKtTest.kt
@@ -124,7 +124,8 @@ internal class ContactStoreDSLKtTest {
 
         override fun fetchContacts(
             predicate: ContactPredicate?,
-            columnsToFetch: List<ContactColumn>
+            columnsToFetch: List<ContactColumn>,
+            displayNameStyle: DisplayNameStyle
         ): Flow<List<Contact>> {
             return emptyFlow()
         }


### PR DESCRIPTION
The preferred style for the [Contact.displayName] to be returned. The fetched contacts' sorting order will match this option.

Example of usage:
```kotlin
contactStore.fetchContacts(
                predicate = ContactLookup(listOf(contactId)),
                displayNameStyle = DisplayNameStyle.Alternative
            ).collect { contacts ->
            val contactString = contacts.joinToString(", ") {
                        "DisplayName = ${it.displayName}, isStarred = ${it.isStarred}, id = ${it.contactId}"
              }
              println("Contacts emitted: $contactString")
        }
```