### PR TITLE
Data class API Changes

### DIFF
--- a/library-test/build.gradle
+++ b/library-test/build.gradle
@@ -50,4 +50,5 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore.test
 
+import android.net.Uri
 import com.alexstyl.contactstore.ContactColumn
 import com.alexstyl.contactstore.ExperimentalContactStoreApi
 import com.alexstyl.contactstore.GroupMembership
@@ -15,8 +16,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @ExperimentalContactStoreApi
+@RunWith(RobolectricTestRunner::class)
 internal class ColumnTestContactStoreTest {
     @Test
     fun `fetches minimum details from snapshot`(): Unit = runBlocking {
@@ -259,7 +263,7 @@ internal class ColumnTestContactStoreTest {
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = listOf(ContactColumn.WebAddresses),
                 webAddresses = listOf(
-                    LabeledValue(WebAddress("www.web.com"), Label.WebsiteHomePage)
+                    LabeledValue(WebAddress(Uri.parse("www.web.com")), Label.WebsiteHomePage)
                 ),
                 lookupKey = null,
             )

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ExecuteTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ExecuteTestContactStoreTest.kt
@@ -10,8 +10,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @ExperimentalContactStoreApi
+@RunWith(RobolectricTestRunner::class)
 internal class ExecuteTestContactStoreTest {
     @Test
     fun `inserts contact`(): Unit = runBlocking {

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/Fixtures.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/Fixtures.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore.test
 
+import android.net.Uri
 import com.alexstyl.contactstore.EventDate
 import com.alexstyl.contactstore.GroupMembership
 import com.alexstyl.contactstore.ImageData
@@ -38,7 +39,7 @@ internal object SnapshotFixtures {
         organization = "Organization",
         jobTitle = "Job Title",
         webAddresses = listOf(
-            LabeledValue(WebAddress("www.web.com"), Label.WebsiteHomePage)
+            LabeledValue(WebAddress(Uri.parse("www.web.com")), Label.WebsiteHomePage)
         ),
         events = listOf(
             LabeledValue(EventDate(1, 1, 2021), Label.DateBirthday)
@@ -73,7 +74,7 @@ internal object ContactFixtures {
         organization = "Organization",
         jobTitle = "Job Title",
         webAddresses = listOf(
-            LabeledValue(WebAddress("www.web.com"), Label.WebsiteHomePage)
+            LabeledValue(WebAddress(Uri.parse("www.web.com")), Label.WebsiteHomePage)
         ),
         events = listOf(
             LabeledValue(EventDate(1, 1, 2021), Label.DateBirthday)

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
@@ -12,8 +12,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
 @ExperimentalContactStoreApi
+@RunWith(RobolectricTestRunner::class)
 internal class PredicateTestContactStoreTest {
     @Test
     fun `phone lookup`(): Unit = runBlocking {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,7 +47,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation 'androidx.annotation:annotation:1.3.0'
 
@@ -57,4 +56,5 @@ dependencies {
     androidTestImplementation "androidx.test:core:$testCoreVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/library/src/androidTest/java/com/alexstyl/contactstore/AddValuesToExistingContactContactStoreTest.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/AddValuesToExistingContactContactStoreTest.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
 import com.alexstyl.contactstore.ContactColumn.Events
 import com.alexstyl.contactstore.ContactColumn.ImAddresses
 import com.alexstyl.contactstore.ContactColumn.Mails
@@ -142,7 +143,7 @@ internal class AddValuesToExistingContactContactStoreTest : ContactStoreTestBase
         val expected = contact.mutableCopy {
             webAddresses.add(
                 LabeledValue(
-                    WebAddress("https://web/address"),
+                    WebAddress(Uri.parse("https://web/address")),
                     Label.WebsiteProfile
                 )
             )

--- a/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreInsertContactTest.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreInsertContactTest.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
 import com.alexstyl.contactstore.ContactColumn.Events
 import com.alexstyl.contactstore.ContactColumn.ImAddresses
 import com.alexstyl.contactstore.ContactColumn.Mails
@@ -217,7 +218,7 @@ internal class ContactStoreInsertContactTest : ContactStoreTestBase() {
                 MutableContact().apply {
                     webAddresses.add(
                         LabeledValue(
-                            value = WebAddress("https://acme.corp"),
+                            value = WebAddress(Uri.parse("https://acme.corp")),
                             label = Label.WebsiteHomePage,
                             id = 0
                         )
@@ -231,7 +232,7 @@ internal class ContactStoreInsertContactTest : ContactStoreTestBase() {
             columns = listOf(WebAddresses),
             webAddresses = listOf(
                 LabeledValue(
-                    WebAddress("https://acme.corp"),
+                    WebAddress(Uri.parse("https://acme.corp")),
                     Label.WebsiteHomePage,
                     id = 0
                 )

--- a/library/src/androidTest/java/com/alexstyl/contactstore/UpdatesValuesOfExistingContactContactStoreTest.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/UpdatesValuesOfExistingContactContactStoreTest.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
 import com.alexstyl.contactstore.ContactColumn.*
 import com.alexstyl.contactstore.Label.LocationHome
 import kotlinx.coroutines.runBlocking
@@ -115,7 +116,7 @@ internal class UpdatesValuesOfExistingContactContactStoreTest : ContactStoreTest
             firstName = "Paolo"
             lastName = "Melendez"
             webAddresses.add(
-                LabeledValue(WebAddress("https://web/address"), Label.WebsiteProfile)
+                LabeledValue(WebAddress(Uri.parse("https://web/address")), Label.WebsiteProfile)
             )
         }
 
@@ -124,7 +125,7 @@ internal class UpdatesValuesOfExistingContactContactStoreTest : ContactStoreTest
             webAddresses.replaceId(
                 id,
                 LabeledValue(
-                    WebAddress("https://web/address.com"),
+                    WebAddress(Uri.parse("https://web/address.com")),
                     Label.WebsiteProfile,
                     id
                 )

--- a/library/src/main/java/com/alexstyl/contactstore/Contact.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/Contact.kt
@@ -98,8 +98,7 @@ public interface Contact {
     /**
      * Requires: [ContactColumn.Image]
      *
-     * *NOTE*: If you need the contact image for UI purposes, you probably need [Contact.imageUri] instead.
-     * [ImageData] contains the raw [ByteArray] of the image, which might consume a lot of memory.
+     * *NOTE*: Consider using [Contact.thumbnailUri] instead if you do not need the high-res version of the photo.
      */
     public val imageData: ImageData?
 
@@ -237,10 +236,19 @@ public fun Contact.mutableCopy(): MutableContact {
 }
 
 /**
- * Creates a [Uri] pointing to the image assigned to the contact
+ * Creates a [Uri] pointing to the thumbnail image assigned to the contact
  */
-public val Contact.imageUri: Uri
+public val Contact.thumbnailUri: Uri
     get() {
         val contactUri = ContentUris.withAppendedId(Contacts.CONTENT_URI, contactId)
         return Uri.withAppendedPath(contactUri, Photo.CONTENT_DIRECTORY)
+    }
+
+@Deprecated(
+    "This function has been renamed and will be removed in 1.0.0",
+    ReplaceWith("thumbnailUri")
+)
+public val Contact.imageUri: Uri
+    get() {
+        return thumbnailUri
     }

--- a/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
@@ -27,7 +27,6 @@ import android.provider.ContactsContract.Data
 import android.provider.ContactsContract.FullNameStyle
 import android.provider.ContactsContract.PhoneticNameStyle
 import android.provider.ContactsContract.RawContacts
-import android.util.Log
 import com.alexstyl.contactstore.ContactColumn.*
 import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
@@ -266,12 +265,8 @@ internal class ContactQueries(
                     }
                     GroupColumns.CONTENT_ITEM_TYPE -> {
                         val groupId = row[GroupColumns.GROUP_ROW_ID].toLongOrNull()
-                        val id = row[GroupColumns._ID].toLongOrNull()
-                        if (groupId != null && id != null) {
-                            groupIds.add(GroupMembership(_id = id, groupId = groupId))
-                        } else {
-                            Log.e("parse error", "Error parsing groupId: $groupId or id: $groupId ")
-                            return@iterate
+                        if (groupId != null) {
+                            groupIds.add(GroupMembership(groupId))
                         }
                     }
                     NameColumns.CONTENT_ITEM_TYPE -> {

--- a/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
@@ -322,7 +322,7 @@ internal class ContactQueries(
                         val webAddressString = row[WebColumns.URL]
                         val id = row[WebColumns._ID].toLongOrNull()
                         if (webAddressString.isNotBlank() && id != null) {
-                            val mailAddress = WebAddress(webAddressString)
+                            val mailAddress = WebAddress(Uri.parse(webAddressString))
                             webAddresses.add(
                                 LabeledValue(mailAddress, webLabelFrom(row), id)
                             )

--- a/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
@@ -540,13 +540,7 @@ internal class ContactQueries(
             if (standardColumns.isNotEmpty()) {
                 append(
                     " ${Data.MIMETYPE} IN ${
-                        valueIn(standardColumns.map { column ->
-                            when (column) {
-                                is LinkedAccountValues ->
-                                    error("Tried to map a LinkedAccountColumn as standard column")
-                                else -> "?"
-                            }
-                        })
+                        valueIn(List(standardColumns.size) { "?" })
                     }"
                 )
             }
@@ -556,7 +550,7 @@ internal class ContactQueries(
                 }
                 append(
                     " ${RawContacts.ACCOUNT_TYPE} IN ${
-                        valueIn(linkedAccountColumns.map { "?" })
+                        valueIn(List(linkedAccountColumns.size) { "?" })
                     }"
                 )
             }

--- a/library/src/main/java/com/alexstyl/contactstore/ContactStoreDSL.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactStoreDSL.kt
@@ -1,6 +1,7 @@
 package com.alexstyl.contactstore
 
 public suspend fun ContactStore.execute(request: SaveRequest.() -> Unit) {
+    @Suppress("DEPRECATION")
     execute(SaveRequest().apply(request))
 }
 

--- a/library/src/main/java/com/alexstyl/contactstore/DataClasses.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/DataClasses.kt
@@ -1,5 +1,7 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
+
 public data class MailAddress(val raw: String)
 
 public data class Note(val raw: String)
@@ -25,7 +27,13 @@ public data class ImageData(val raw: ByteArray) {
 
 public data class PhoneNumber(val raw: String)
 
-public data class WebAddress(val raw: String)
+public data class WebAddress(val raw: Uri)
+
+@Deprecated(
+    "This function will be removed in 1.0.0",
+    ReplaceWith("WebAddress(Uri.parse(raw))", "import android.net.Uri")
+)
+public fun WebAddress(raw: String): WebAddress = WebAddress(Uri.parse(raw))
 
 public data class PostalAddress(
     val street: String,

--- a/library/src/main/java/com/alexstyl/contactstore/DataClasses.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/DataClasses.kt
@@ -59,10 +59,7 @@ public fun PostalAddress(fullAddress: String): PostalAddress {
     )
 }
 
-public data class GroupMembership(
-    val groupId: Long,
-    val _id: Long? = null,
-)
+public data class GroupMembership(val groupId: Long)
 
 public data class ImAddress(
     val raw: String,
@@ -70,10 +67,6 @@ public data class ImAddress(
 )
 
 public data class SipAddress(val raw: String)
-
-internal fun GroupMembership.requireId(): Long {
-    return requireNotNull(_id)
-}
 
 public data class LookupKey(val value: String)
 

--- a/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
@@ -400,7 +400,7 @@ internal class ExistingContactOperationsFactory(
             oldValues = oldContact.webAddresses,
             newValues = newContact.webAddresses
         ) { labeledValue ->
-            withValue(WebAddressColumns.URL, labeledValue.value.raw)
+            withValue(WebAddressColumns.URL, labeledValue.value.raw.toString())
                 .withWebAddressLabel(labeledValue.label)
         }
     }

--- a/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
@@ -92,9 +92,9 @@ internal class ExistingContactOperationsFactory(
         } + deleted.map { value ->
             newDelete(Data.CONTENT_URI)
                 .withSelection(
-                    "${Data.CONTACT_ID} = $forContactId" +
-                            " AND ${Data.MIMETYPE} = ?" +
-                            " AND ${Data._ID} = ${value.requireId()}",
+                    "${GroupsColumns.CONTACT_ID} = $forContactId" +
+                            " AND ${GroupsColumns.MIMETYPE} = ?" +
+                            " AND ${GroupsColumns.GROUP_ROW_ID} = ${value.groupId}",
                     arrayOf(GroupsColumns.CONTENT_ITEM_TYPE)
                 )
                 .build()

--- a/library/src/main/java/com/alexstyl/contactstore/MutableContactBuilder.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/MutableContactBuilder.kt
@@ -1,5 +1,6 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
 import android.provider.ContactsContract
 
 public data class MutableContactBuilder(
@@ -110,7 +111,12 @@ public data class MutableContactBuilder(
         )
     }
 
+    @Deprecated("Use the Uri version instead. This function will be removed in version 1.0.0")
     public fun webAddress(address: String, label: Label) {
+        _webAddresses.add(LabeledValue(WebAddress(Uri.parse(address)), label))
+    }
+
+    public fun webAddress(address: Uri, label: Label) {
         _webAddresses.add(LabeledValue(WebAddress(address), label))
     }
 

--- a/library/src/main/java/com/alexstyl/contactstore/NewContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/NewContactOperationsFactory.kt
@@ -66,7 +66,7 @@ internal class NewContactOperationsFactory {
         return newInsert(Data.CONTENT_URI)
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, WebsiteColumns.CONTENT_ITEM_TYPE)
-            .withValue(WebsiteColumns.URL, labeledValue.value.raw)
+            .withValue(WebsiteColumns.URL, labeledValue.value.raw.toString())
             .withWebsiteLabel(labeledValue.label)
             .build()
     }

--- a/library/src/test/java/com/alexstyl/contactstore/ContactStoreDSLKtTest.kt
+++ b/library/src/test/java/com/alexstyl/contactstore/ContactStoreDSLKtTest.kt
@@ -1,11 +1,15 @@
 package com.alexstyl.contactstore
 
+import android.net.Uri
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 internal class ContactStoreDSLKtTest {
 
     @Test
@@ -46,7 +50,7 @@ internal class ContactStoreDSLKtTest {
                 )
 
                 webAddress(
-                    address = "www.paolo.com",
+                    address = Uri.parse("www.paolo.com"),
                     label = Label.LocationWork
                 )
                 groupMembership(groupId = 123)
@@ -98,7 +102,7 @@ internal class ContactStoreDSLKtTest {
 
                     webAddresses.add(
                         LabeledValue(
-                            value = WebAddress("www.paolo.com"),
+                            value = WebAddress(Uri.parse("www.paolo.com")),
                             label = Label.LocationWork
                         )
                     )

--- a/versions.gradle
+++ b/versions.gradle
@@ -21,4 +21,5 @@ ext {
     testCoreVersion = '1.4.0'
     gradleNexusVersion = '1.1.0'
     assertjVersion = '3.21.0'
+    robolectricVersion = '4.5.1'
 }


### PR DESCRIPTION
This PR introduces the following changes:

* Makes `WebAddress` raw value to Uri (from String)
* Renames `Contact#imageUri` to `Contact#thumbnailUri` to make point out the image quality you receive when using it.
* Removes the _id field of GroupMembership as it is not really required to manage the user's groups.