### PR TITLE
Introduce samePropertiesAs() matcher to compare two contacts losely

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 19 16:55:44 BST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library-test/build.gradle
+++ b/library-test/build.gradle
@@ -48,7 +48,7 @@ android {
 dependencies {
     implementation project(':library')
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
+    implementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "junit:junit:$junitVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }

--- a/library-test/src/test/java/com/alexstyl/contactstore/ColumnTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/ColumnTestContactStoreTest.kt
@@ -1,17 +1,7 @@
-package com.alexstyl.contactstore.test
+package com.alexstyl.contactstore
 
 import android.net.Uri
-import com.alexstyl.contactstore.ContactColumn
-import com.alexstyl.contactstore.ExperimentalContactStoreApi
-import com.alexstyl.contactstore.GroupMembership
-import com.alexstyl.contactstore.ImageData
-import com.alexstyl.contactstore.Label
-import com.alexstyl.contactstore.LabeledValue
-import com.alexstyl.contactstore.MailAddress
-import com.alexstyl.contactstore.Note
-import com.alexstyl.contactstore.PartialContact
-import com.alexstyl.contactstore.PostalAddress
-import com.alexstyl.contactstore.WebAddress
+import com.alexstyl.contactstore.test.TestContactStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions

--- a/library-test/src/test/java/com/alexstyl/contactstore/ExecuteTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/ExecuteTestContactStoreTest.kt
@@ -1,10 +1,6 @@
-package com.alexstyl.contactstore.test
+package com.alexstyl.contactstore
 
-import com.alexstyl.contactstore.ExperimentalContactStoreApi
-import com.alexstyl.contactstore.MutableContact
-import com.alexstyl.contactstore.PartialContact
-import com.alexstyl.contactstore.mutableCopy
-import com.alexstyl.contactstore.standardColumns
+import com.alexstyl.contactstore.test.TestContactStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat

--- a/library-test/src/test/java/com/alexstyl/contactstore/Fixtures.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/Fixtures.kt
@@ -1,18 +1,7 @@
-package com.alexstyl.contactstore.test
+package com.alexstyl.contactstore
 
 import android.net.Uri
-import com.alexstyl.contactstore.EventDate
-import com.alexstyl.contactstore.GroupMembership
-import com.alexstyl.contactstore.ImageData
-import com.alexstyl.contactstore.Label
-import com.alexstyl.contactstore.LabeledValue
-import com.alexstyl.contactstore.MailAddress
-import com.alexstyl.contactstore.Note
-import com.alexstyl.contactstore.PartialContact
-import com.alexstyl.contactstore.PhoneNumber
-import com.alexstyl.contactstore.PostalAddress
-import com.alexstyl.contactstore.WebAddress
-import com.alexstyl.contactstore.standardColumns
+import com.alexstyl.contactstore.test.StoredContact
 
 internal object SnapshotFixtures {
     val KIM_CLAY = StoredContact(

--- a/library-test/src/test/java/com/alexstyl/contactstore/PredicateTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/PredicateTestContactStoreTest.kt
@@ -1,13 +1,10 @@
-package com.alexstyl.contactstore.test
+package com.alexstyl.contactstore
 
 import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
 import com.alexstyl.contactstore.ContactPredicate.NameLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
-import com.alexstyl.contactstore.ExperimentalContactStoreApi
-import com.alexstyl.contactstore.MailAddress
-import com.alexstyl.contactstore.PartialContact
-import com.alexstyl.contactstore.PhoneNumber
+import com.alexstyl.contactstore.test.TestContactStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$testRunnerVersion"
     androidTestImplementation "androidx.test:rules:$testRulesVersion"
     androidTestImplementation "androidx.test:core:$testCoreVersion"
+    
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreTestBase.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreTestBase.kt
@@ -5,6 +5,7 @@ import android.provider.ContactsContract
 import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
+import com.alexstyl.contactstore.test.samePropertiesAs
 import kotlinx.coroutines.flow.first
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -27,7 +28,7 @@ internal abstract class ContactStoreTestBase {
             columnsToFetch = editedContact.columns
         ).first().first()
 
-        assertThat(actual, equalContents(editedContact))
+        assertThat(actual, samePropertiesAs(editedContact))
     }
 
     suspend fun assertContactUpdatedNoId(expected: MutableContact) {
@@ -37,7 +38,7 @@ internal abstract class ContactStoreTestBase {
             columnsToFetch = expected.columns
         ).first().first()
 
-        assertThat(actual, equalContents(expected))
+        assertThat(actual, samePropertiesAs(expected))
     }
 
     protected lateinit var store: ContactStore
@@ -59,10 +60,15 @@ internal abstract class ContactStoreTestBase {
 
     protected fun contact(
         displayName: String? = null,
-        firstName: String? = null,
-        lastName: String? = null,
-        organization: String? = null,
-        jobTitle: String? = null,
+        // defaulting names to "" as Android seems to be returning empty strings instead of null
+        firstName: String = "",
+        lastName: String = "",
+        prefix: String = "",
+        middleName: String = "",
+        suffix: String = "",
+        organization: String = "",
+        jobTitle: String = "",
+        note: Note? = null,
         columns: List<ContactColumn> = emptyList(),
         phones: List<LabeledValue<PhoneNumber>> = emptyList(),
         mails: List<LabeledValue<MailAddress>> = emptyList(),
@@ -71,11 +77,7 @@ internal abstract class ContactStoreTestBase {
         webAddresses: List<LabeledValue<WebAddress>> = emptyList(),
         imAddresses: List<LabeledValue<ImAddress>> = emptyList(),
         sipAddresses: List<LabeledValue<SipAddress>> = emptyList(),
-        relations : List<LabeledValue<Relation>> = emptyList(),
-        note: Note? = null,
-        prefix: String? = null,
-        middleName: String? = null,
-        suffix: String? = null
+        relations: List<LabeledValue<Relation>> = emptyList(),
     ): PartialContact {
         return PartialContact(
             contactId = IGNORED,
@@ -89,6 +91,9 @@ internal abstract class ContactStoreTestBase {
             firstName = firstName,
             lastName = lastName,
             events = events,
+            phoneticFirstName = "",
+            phoneticLastName = "",
+            phoneticMiddleName = "",
             postalAddresses = postalAddresses,
             sipAddresses = sipAddresses,
             note = note,
@@ -119,7 +124,8 @@ internal abstract class ContactStoreTestBase {
 
     protected fun assertOnlyContact(actual: List<Contact>, expected: Contact) {
         assertThat(actual.size, equalTo(1))
-        assertThat(actual.first(), equalContents(expected))
+        assertThat(actual.first(), samePropertiesAs(expected))
+        assertThat(actual.first(), samePropertiesAs(expected))
     }
 
     private companion object {

--- a/library/src/androidTest/java/com/alexstyl/contactstore/test/SamePropertiesMatcher.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/test/SamePropertiesMatcher.kt
@@ -1,0 +1,339 @@
+package com.alexstyl.contactstore.test
+
+import com.alexstyl.contactstore.Contact
+import com.alexstyl.contactstore.ContactColumn
+import com.alexstyl.contactstore.ContactColumn.Events
+import com.alexstyl.contactstore.ContactColumn.GroupMemberships
+import com.alexstyl.contactstore.ContactColumn.ImAddresses
+import com.alexstyl.contactstore.ContactColumn.Image
+import com.alexstyl.contactstore.ContactColumn.Mails
+import com.alexstyl.contactstore.ContactColumn.Names
+import com.alexstyl.contactstore.ContactColumn.Nickname
+import com.alexstyl.contactstore.ContactColumn.Note
+import com.alexstyl.contactstore.ContactColumn.Organization
+import com.alexstyl.contactstore.ContactColumn.Phones
+import com.alexstyl.contactstore.ContactColumn.PostalAddresses
+import com.alexstyl.contactstore.ContactColumn.Relations
+import com.alexstyl.contactstore.ContactColumn.SipAddresses
+import com.alexstyl.contactstore.ContactColumn.WebAddresses
+import com.alexstyl.contactstore.LabeledValue
+import com.alexstyl.contactstore.containsColumn
+import com.alexstyl.contactstore.containsLinkedAccountColumns
+import com.alexstyl.contactstore.standardColumns
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeDiagnosingMatcher
+
+// copy of library-test's SamePropertiesMatcher in order to not have to extract to a 3rd module
+internal fun samePropertiesAs(expected: Contact): Matcher<in Contact> {
+    return SamePropertiesMatcher(expected)
+}
+
+private class SamePropertiesMatcher(
+    private val expected: Contact
+) : TypeSafeDiagnosingMatcher<Contact>() {
+    override fun describeTo(description: Description) {
+        description.appendText("Contact with: ${contentsOf(expected)}")
+    }
+
+    private fun contentsOf(contact: Contact): String {
+        return with(contact) {
+            buildString {
+                append("Columns: ${columns(contact)}")
+                append(" displayName = ${contact.displayName}")
+                append(" isStarred = ${contact.isStarred}")
+
+                if (containsColumn(Names)) {
+                    putCommaIfNeeded()
+                    append(
+                        "prefix = $prefix" +
+                                ", firstName = $firstName" +
+                                ", middleName = $middleName" +
+                                ", lastName = $lastName" +
+                                ", suffix = $suffix" +
+                                ", phoneticFirstName = $phoneticFirstName" +
+                                ", phoneticMiddleName = $phoneticMiddleName" +
+                                ", phoneticLastName = $phoneticLastName"
+                    )
+                }
+                if (containsColumn(Image)) {
+                    putCommaIfNeeded()
+                    append("image = $imageData")
+                }
+                if (containsColumn(Phones)) {
+                    putCommaIfNeeded()
+                    append("phones = ${labeledValues(phones)}")
+                }
+                if (containsColumn(Mails)) {
+                    putCommaIfNeeded()
+                    append("mails = ${labeledValues(mails)}")
+                }
+                if (containsColumn(Organization)) {
+                    putCommaIfNeeded()
+                    append("organization = $organization, jobTitle = $jobTitle")
+                }
+                if (containsColumn(Nickname)) {
+                    putCommaIfNeeded()
+                    append("nickname = $nickname")
+                }
+                if (containsColumn(Relations)) {
+                    putCommaIfNeeded()
+                    append("relations = ${labeledValues(relations)}")
+                }
+                if (containsColumn(WebAddresses)) {
+                    putCommaIfNeeded()
+                    append("webAddresses = ${labeledValues(webAddresses)}")
+                }
+                if (containsColumn(SipAddresses)) {
+                    putCommaIfNeeded()
+                    append("sipAddresses = ${labeledValues(sipAddresses)}")
+                }
+                if (containsColumn(Events)) {
+                    putCommaIfNeeded()
+                    append("events = ${labeledValues(events)}")
+                }
+                if (containsColumn(PostalAddresses)) {
+                    putCommaIfNeeded()
+                    append("postalAddresses = ${labeledValues(postalAddresses)}")
+                }
+                if (containsColumn(Note)) {
+                    putCommaIfNeeded()
+                    append("note = $note")
+                }
+                if (containsColumn(ImAddresses)) {
+                    putCommaIfNeeded()
+                    append("imAddresses = ${labeledValues(imAddresses)}")
+                }
+                if (containsColumn(GroupMemberships)) {
+                    putCommaIfNeeded()
+                    append("groupMemberships = [${groups.joinToString(", ")}]")
+                }
+            }
+        }
+    }
+
+    private fun labeledValues(list: List<LabeledValue<*>>): String {
+        return list.joinToString(", ", prefix = "[", postfix = "]") { labeledValue ->
+            "label = ${labeledValue.label}, value = ${labeledValue.value}"
+        }
+    }
+
+    private fun StringBuilder.putCommaIfNeeded() {
+        if (isEmpty().not()) append(", ")
+    }
+
+    override fun matchesSafely(actual: Contact, mismatchDescription: Description): Boolean {
+        return with(actual) {
+            when {
+                containsDifferentImageData(actual) -> {
+                    mismatchDescription.appendText("ImageData was ${actual.imageData}")
+                    false
+                }
+                containsDifferentColumns(actual) -> {
+                    mismatchDescription.appendText("Columns were ${columns(actual)}")
+                    false
+                }
+                containsDifferentStarred(actual) -> {
+                    mismatchDescription.appendText("phones were ${actual.isStarred}")
+                    false
+                }
+                namesAreDifferent(actual) -> {
+                    mismatchDescription.appendText(
+                        "prefix was '${actual.prefix}'" +
+                                ", firstName was '${actual.firstName}'" +
+                                ", middleName was '${actual.middleName}'" +
+                                ", lastName was '${actual.lastName}'" +
+                                ", suffix was '${actual.suffix}'"
+                    )
+                    false
+                }
+                phoneticNamesAreDifferent(actual) -> {
+                    mismatchDescription.appendText(
+                        "phoneticFirstName was '${actual.phoneticFirstName}'" +
+                                ", phoneticMiddleName was '${actual.phoneticMiddleName}'" +
+                                ", phoneticLastName was '${actual.phoneticLastName}'"
+                    )
+                    false
+                }
+                phonesAreDifferent(actual) -> {
+                    mismatchDescription.appendText("phones were ${labeledValues(actual.phones)}")
+                    false
+                }
+                mailsAreDifferent(actual) -> {
+                    mismatchDescription.appendText("mails were ${labeledValues(actual.mails)}")
+                    false
+                }
+                imAreDifferent(actual) -> {
+                    mismatchDescription.appendText("imAddresses were ${labeledValues(actual.imAddresses)}")
+                    false
+                }
+                sipAreDifferent(actual) -> {
+                    mismatchDescription.appendText("sipAddresses were ${labeledValues(actual.sipAddresses)}")
+                    false
+                }
+                organizationIsDifferent(actual) -> {
+                    mismatchDescription.appendText("organization was ${actual.organization}, jobTitle was ${actual.jobTitle}")
+                    false
+                }
+                eventsAreDifferent(actual) -> {
+                    mismatchDescription.appendText("events were ${labeledValues(actual.events)}")
+                    false
+                }
+                postalAreDifferent(actual) -> {
+                    mismatchDescription.appendText("postalAddresses were ${labeledValues(actual.postalAddresses)}")
+                    false
+                }
+                webAddressesAreDifferent(actual) -> {
+                    mismatchDescription.appendText("webAddresses were ${labeledValues(actual.webAddresses)}")
+                    false
+                }
+                notesAreDifferent(actual) -> {
+                    mismatchDescription.appendText("note was ${actual.note}")
+                    false
+                }
+                relationsAreDifferent(actual) -> {
+                    mismatchDescription.appendText("relations were ${actual.relations}")
+                    false
+                }
+                linkedAccountsAreDifferent(actual) -> {
+                    mismatchDescription.appendText("linkedAccountValues were ${actual.linkedAccountValues}")
+                    false
+                }
+                displayName != expected.displayName -> {
+                    mismatchDescription.appendText("display name was '${actual.displayName}'")
+                    false
+                }
+                else -> true
+            }
+        }
+    }
+
+    private fun relationsAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(Relations).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(actual.relations, expected.relations)
+    }
+
+    private fun linkedAccountsAreDifferent(actual: Contact): Boolean {
+        if (expected.containsLinkedAccountColumns().not()) {
+            return false
+        }
+        val map = actual.linkedAccountValues.map { it.copy(id = 0) }
+        val map1 = expected.linkedAccountValues.map { it.copy(id = 0) }
+        return map != map1
+    }
+
+    private fun imAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(ImAddresses).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(actual.imAddresses, expected.imAddresses)
+    }
+
+    private fun sipAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(SipAddresses).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(actual.sipAddresses, expected.sipAddresses)
+    }
+
+    private fun namesAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(Names).not()) {
+            return false
+        }
+        return actual.prefix != expected.prefix
+                || actual.firstName != expected.firstName
+                || actual.middleName != expected.middleName
+                || actual.lastName != expected.lastName
+                || actual.suffix != expected.suffix
+    }
+
+    private fun phoneticNamesAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(Names).not()) {
+            return false
+        }
+        return actual.phoneticFirstName != expected.phoneticFirstName
+                || actual.phoneticMiddleName != expected.phoneticMiddleName
+                || actual.phoneticLastName != expected.phoneticLastName
+    }
+
+    private fun notesAreDifferent(contact: Contact): Boolean {
+        if (expected.containsColumn(Note).not()) {
+            return false
+        }
+        return contact.note != expected.note
+    }
+
+    private fun containsDifferentColumns(contact: Contact): Boolean {
+        return columns(expected) != columns(contact)
+    }
+
+    private fun containsDifferentStarred(contact: Contact): Boolean {
+        return contact.isStarred != expected.isStarred
+    }
+
+    private fun columns(contact: Contact): List<ContactColumn> {
+        return standardColumns()
+            .filter { contact.containsColumn(it) }
+    }
+
+    private fun phonesAreDifferent(contact: Contact): Boolean {
+        if (expected.containsColumn(Phones).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(contact.phones, expected.phones)
+    }
+
+    private fun organizationIsDifferent(contact: Contact): Boolean {
+        if (expected.containsColumn(Organization).not()) {
+            return false
+        }
+        return expected.organization != contact.organization ||
+                expected.jobTitle != contact.jobTitle
+    }
+
+    private fun mailsAreDifferent(contact: Contact): Boolean {
+        if (expected.containsColumn(Mails).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(contact.mails, expected.mails)
+    }
+
+    private fun containsDifferentImageData(contact: Contact): Boolean {
+        if (expected.containsColumn(Image).not()) {
+            return false
+        }
+        return contact.imageData != expected.imageData
+    }
+
+    private fun eventsAreDifferent(contact: Contact): Boolean {
+        if (expected.containsColumn(Events).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(contact.events, expected.events)
+    }
+
+    private fun postalAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(PostalAddresses).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(actual.postalAddresses, expected.postalAddresses)
+    }
+
+    private fun webAddressesAreDifferent(actual: Contact): Boolean {
+        if (expected.containsColumn(WebAddresses).not()) {
+            return false
+        }
+        return areLabeledValuesDifferentIgnoringId(actual.webAddresses, expected.webAddresses)
+    }
+
+    private fun <T : Any> areLabeledValuesDifferentIgnoringId(
+        one: List<LabeledValue<T>>,
+        other: List<LabeledValue<T>>
+    ): Boolean {
+        val map = one.map { it.copy(id = 0) }
+        val map1 = other.map { it.copy(id = 0) }
+        return map != map1
+    }
+}

--- a/library/src/main/java/com/alexstyl/contactstore/DisplayName.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/DisplayName.kt
@@ -10,7 +10,7 @@ import com.alexstyl.contactstore.ContactColumn.Phones
 
 /**
  * Creates a display name of the given contact according to the
- * priority menitoned in [android.provider.ContactsContract.DisplayNameSources]
+ * priority mentioned in [android.provider.ContactsContract.DisplayNameSources]
  */
 internal fun MutableContact.displayName(): String {
     return buildString {

--- a/versions.gradle
+++ b/versions.gradle
@@ -11,7 +11,7 @@ ext {
     androidMinSdkVersion = 14
 
     r8Version = '3.0.73'
-    gradlePluginVersion = '7.0.4'
+    gradlePluginVersion = '7.1.0'
     kotlinVersion = '1.5.31'
     coroutinesVersion = '1.6.0'
     hiltVersion = '2.40.5'


### PR DESCRIPTION
This PR introduces the samePropertiesAs() matcher, which matches when the examining object is logically equal to the passing Contact, minus any ids or lookup keys.

As an example, two contacts that both contain the same phone number will match, even if their contactIds or phone ids are different.

This is useful when you cannot know expected ids in advance, such as setting up contacts in Android connected Tests