### PR TITLE
Use any kind of Label as custom label value when creating a CP operation

### DIFF
--- a/library/src/main/java/com/alexstyl/contactstore/AndroidContactStore.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/AndroidContactStore.kt
@@ -7,6 +7,7 @@ import com.alexstyl.contactstore.ContactOperation.Insert
 import com.alexstyl.contactstore.ContactOperation.Update
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 internal class AndroidContactStore(
@@ -43,5 +44,6 @@ internal class AndroidContactStore(
         displayNameStyle: DisplayNameStyle
     ): Flow<List<Contact>> {
         return contactQueries.queryContacts(predicate, columnsToFetch, displayNameStyle)
+            .flowOn(Dispatchers.IO)
     }
 }

--- a/library/src/main/java/com/alexstyl/contactstore/ApplyLabelOperation.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ApplyLabelOperation.kt
@@ -1,0 +1,308 @@
+package com.alexstyl.contactstore
+
+import android.content.ContentProviderOperation
+import android.content.res.Resources
+import android.provider.ContactsContract.CommonDataKinds
+import android.provider.ContactsContract.CommonDataKinds.Contactables
+import android.provider.ContactsContract.CommonDataKinds.Email
+import android.provider.ContactsContract.CommonDataKinds.Event
+import android.provider.ContactsContract.CommonDataKinds.Im
+import android.provider.ContactsContract.CommonDataKinds.Organization
+import android.provider.ContactsContract.CommonDataKinds.Phone
+import android.provider.ContactsContract.CommonDataKinds.Relation
+import android.provider.ContactsContract.CommonDataKinds.StructuredPostal
+import android.provider.ContactsContract.CommonDataKinds.Website
+
+internal fun ContentProviderOperation.Builder.withPhoneLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.PhoneNumberMobile -> withValue(Contactables.TYPE, Phone.TYPE_MOBILE)
+        Label.LocationHome -> withValue(Contactables.TYPE, Phone.TYPE_HOME)
+        Label.LocationWork -> withValue(Contactables.TYPE, Phone.TYPE_WORK)
+        Label.PhoneNumberPager -> withValue(Contactables.TYPE, Phone.TYPE_PAGER)
+        Label.PhoneNumberCar -> withValue(Contactables.TYPE, Phone.TYPE_CAR)
+        Label.PhoneNumberFaxWork -> withValue(Contactables.TYPE, Phone.TYPE_FAX_WORK)
+        Label.PhoneNumberFaxHome -> withValue(Contactables.TYPE, Phone.TYPE_FAX_HOME)
+        Label.PhoneNumberCallback -> withValue(Contactables.TYPE, Phone.TYPE_CALLBACK)
+        Label.PhoneNumberCompanyMain -> withValue(Contactables.TYPE, Phone.TYPE_COMPANY_MAIN)
+        Label.PhoneNumberIsdn -> withValue(Contactables.TYPE, Phone.TYPE_ISDN)
+        Label.Main -> withValue(Contactables.TYPE, Phone.TYPE_MAIN)
+        Label.PhoneNumberOtherFax -> withValue(Contactables.TYPE, Phone.TYPE_OTHER_FAX)
+        Label.PhoneNumberRadio -> withValue(Contactables.TYPE, Phone.TYPE_RADIO)
+        Label.PhoneNumberTelex -> withValue(Contactables.TYPE, Phone.TYPE_TELEX)
+        Label.PhoneNumberTtyTdd -> withValue(Contactables.TYPE, Phone.TYPE_TTY_TDD)
+        Label.PhoneNumberWorkPager -> withValue(Contactables.TYPE, Phone.TYPE_WORK_PAGER)
+        Label.PhoneNumberWorkMobile -> withValue(Contactables.TYPE, Phone.TYPE_WORK_MOBILE)
+        Label.PhoneNumberAssistant -> withValue(Contactables.TYPE, Phone.TYPE_ASSISTANT)
+        Label.PhoneNumberMms -> withValue(Contactables.TYPE, Phone.TYPE_MMS)
+        Label.Other -> withValue(Contactables.TYPE, Phone.TYPE_OTHER)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withMailLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.LocationHome -> withValue(Contactables.TYPE, Email.TYPE_HOME)
+        Label.LocationWork -> withValue(Contactables.TYPE, Email.TYPE_WORK)
+        Label.Other -> withValue(Contactables.TYPE, Email.TYPE_OTHER)
+        Label.PhoneNumberMobile -> withValue(Contactables.TYPE, Email.TYPE_MOBILE)
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withRelationLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.PhoneNumberAssistant -> withValue(Contactables.TYPE, Relation.TYPE_ASSISTANT)
+        Label.RelationBrother -> withValue(Contactables.TYPE, Relation.TYPE_BROTHER)
+        Label.RelationDomesticPartner -> withValue(
+            Contactables.TYPE, Relation.TYPE_DOMESTIC_PARTNER
+        )
+        Label.RelationChild -> withValue(Contactables.TYPE, Relation.TYPE_CHILD)
+        Label.RelationFather -> withValue(Contactables.TYPE, Relation.TYPE_FATHER)
+        Label.RelationMother -> withValue(Contactables.TYPE, Relation.TYPE_MOTHER)
+        Label.RelationManager -> withValue(Contactables.TYPE, Relation.TYPE_MANAGER)
+        Label.RelationFriend -> withValue(Contactables.TYPE, Relation.TYPE_FRIEND)
+        Label.RelationParent -> withValue(Contactables.TYPE, Relation.TYPE_PARENT)
+        Label.RelationPartner -> withValue(Contactables.TYPE, Relation.TYPE_PARTNER)
+        Label.RelationReferredBy -> withValue(Contactables.TYPE, Relation.TYPE_REFERRED_BY)
+        Label.RelationSister -> withValue(Contactables.TYPE, Relation.TYPE_SISTER)
+        Label.RelationSpouse -> withValue(Contactables.TYPE, Relation.TYPE_SPOUSE)
+        Label.RelationRelative -> withValue(Contactables.TYPE, Relation.TYPE_RELATIVE)
+        Label.Other -> withValue(Contactables.TYPE, Relation.TYPE_CHILD)
+        is Label.Custom -> withValue(
+            Contactables.TYPE,
+            Contactables.TYPE_CUSTOM
+        )
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withSipLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.LocationHome -> withValue(Contactables.TYPE, CommonDataKinds.SipAddress.TYPE_HOME)
+        Label.Other -> withValue(Contactables.TYPE, CommonDataKinds.SipAddress.TYPE_OTHER)
+        Label.LocationWork -> withValue(Contactables.TYPE, CommonDataKinds.SipAddress.TYPE_WORK)
+        is Label.Custom -> withValue(
+            Contactables.TYPE,
+            Contactables.TYPE_CUSTOM
+        )
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withPostalAddressLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.LocationHome -> withValue(Contactables.TYPE, StructuredPostal.TYPE_HOME)
+        Label.LocationWork -> withValue(Contactables.TYPE, StructuredPostal.TYPE_WORK)
+        Label.Other -> withValue(Contactables.TYPE, StructuredPostal.TYPE_OTHER)
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withImLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.LocationHome -> withValue(Contactables.TYPE, Im.TYPE_HOME)
+        Label.LocationWork -> withValue(Contactables.TYPE, Im.TYPE_WORK)
+        Label.Other -> withValue(Contactables.TYPE, Im.TYPE_OTHER)
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withWebAddressLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.WebsiteProfile -> withValue(Contactables.TYPE, Website.TYPE_PROFILE)
+        Label.LocationWork -> withValue(Contactables.TYPE, Website.TYPE_WORK)
+        Label.WebsiteHomePage -> withValue(Contactables.TYPE, Website.TYPE_HOMEPAGE)
+        Label.WebsiteFtp -> withValue(Contactables.TYPE, Website.TYPE_FTP)
+        Label.WebsiteBlog -> withValue(Contactables.TYPE, Website.TYPE_BLOG)
+        Label.Other -> withValue(Contactables.TYPE, Website.TYPE_OTHER)
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+internal fun ContentProviderOperation.Builder.withEventLabel(
+    label: Label, resources: Resources
+): ContentProviderOperation.Builder {
+    return when (label) {
+        Label.DateAnniversary -> withValue(Contactables.TYPE, Event.TYPE_ANNIVERSARY)
+        Label.DateBirthday -> withValue(Contactables.TYPE, Event.TYPE_BIRTHDAY)
+        Label.Other -> withValue(Contactables.TYPE, Event.TYPE_OTHER)
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        else -> withCustomLabel(resources, label)
+    }
+}
+
+private fun ContentProviderOperation.Builder.withCustomLabel(
+    resources: Resources,
+    stringResId: Int
+): ContentProviderOperation.Builder {
+    return withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+        .withValue(Contactables.LABEL, resources.getString(stringResId))
+}
+
+
+private fun ContentProviderOperation.Builder.withCustomLabel(
+    resources: Resources,
+    column: ContactColumn,
+    type: Int
+): ContentProviderOperation.Builder {
+    val typeResource = when (column) {
+        ContactColumn.Events -> Event.getTypeResource(type)
+        ContactColumn.ImAddresses -> Im.getTypeLabelResource(type)
+        ContactColumn.Phones -> Phone.getTypeLabelResource(type)
+        ContactColumn.Mails -> Email.getTypeLabelResource(type)
+        ContactColumn.Organization -> Organization.getTypeLabelResource(type)
+        ContactColumn.PostalAddresses -> StructuredPostal.getTypeLabelResource(type)
+        ContactColumn.Relations -> Relation.getTypeLabelResource(type)
+        ContactColumn.SipAddresses -> CommonDataKinds.SipAddress.getTypeLabelResource(type)
+        ContactColumn.WebAddresses -> error("WebAddress label case was unhandled")
+        ContactColumn.Note,
+        ContactColumn.Names,
+        ContactColumn.Nickname,
+        is ContactColumn.LinkedAccountValues,
+        ContactColumn.Image,
+        ContactColumn.GroupMemberships -> error(
+            "Tried to get label for a ${column.javaClass.simpleName}"
+        )
+    }
+
+    return withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+        .withValue(Contactables.LABEL, resources.getString(typeResource))
+}
+
+private fun ContentProviderOperation.Builder.withCustomLabel(
+    resources: Resources,
+    label: Label
+): ContentProviderOperation.Builder {
+    return when (label) {
+        is Label.Custom -> withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+            .withValue(Contactables.LABEL, label.label)
+        Label.DateBirthday -> {
+            val typeResource = Event.getTypeResource(Event.TYPE_BIRTHDAY)
+            withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
+                .withValue(Contactables.LABEL, resources.getString(typeResource))
+        }
+        Label.DateAnniversary -> withCustomLabel(
+            resources, ContactColumn.Events, Event.TYPE_ANNIVERSARY
+        )
+        Label.RelationBrother -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_BROTHER
+        )
+        Label.RelationChild -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_CHILD
+        )
+        Label.RelationDomesticPartner -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_DOMESTIC_PARTNER
+        )
+        Label.RelationFather -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_FATHER
+        )
+        Label.RelationFriend -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_FRIEND
+        )
+        Label.RelationManager -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_MANAGER
+        )
+        Label.RelationMother -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_MOTHER
+        )
+        Label.RelationParent -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_PARENT
+        )
+        Label.RelationPartner -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_PARTNER
+        )
+        Label.RelationReferredBy -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_REFERRED_BY
+        )
+        Label.RelationRelative -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_RELATIVE
+        )
+        Label.RelationSister -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_SISTER
+        )
+        Label.RelationSpouse -> withCustomLabel(
+            resources, ContactColumn.Relations, Relation.TYPE_SPOUSE
+        )
+        Label.WebsiteBlog -> withCustomLabel(resources, R.string.blog)
+        Label.WebsiteFtp -> withCustomLabel(resources, R.string.ftp)
+        Label.WebsiteHomePage -> withCustomLabel(resources, R.string.home_page)
+        Label.WebsiteProfile -> withCustomLabel(resources, R.string.profile)
+        Label.LocationHome -> withCustomLabel(
+            resources, ContactColumn.PostalAddresses, StructuredPostal.TYPE_HOME
+        )
+        Label.LocationWork -> withCustomLabel(
+            resources, ContactColumn.PostalAddresses, StructuredPostal.TYPE_WORK
+        )
+        Label.Main -> withCustomLabel(resources, ContactColumn.Phones, Phone.TYPE_MAIN)
+        Label.Other -> withCustomLabel(resources, ContactColumn.Phones, Phone.TYPE_OTHER)
+        Label.PhoneNumberAssistant -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_ASSISTANT
+        )
+        Label.PhoneNumberCallback -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_CALLBACK
+        )
+        Label.PhoneNumberCar -> withCustomLabel(resources, ContactColumn.Phones, Phone.TYPE_CAR)
+        Label.PhoneNumberCompanyMain -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_COMPANY_MAIN
+        )
+        Label.PhoneNumberFaxHome -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_FAX_HOME
+        )
+        Label.PhoneNumberFaxWork -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_FAX_WORK
+        )
+        Label.PhoneNumberIsdn -> withCustomLabel(resources, ContactColumn.Phones, Phone.TYPE_ISDN)
+        Label.PhoneNumberMms -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_MMS
+        )
+        Label.PhoneNumberMobile -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_MOBILE
+        )
+        Label.PhoneNumberOtherFax -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_OTHER_FAX
+        )
+        Label.PhoneNumberPager -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_PAGER
+        )
+        Label.PhoneNumberRadio -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_RADIO
+        )
+        Label.PhoneNumberTelex -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_TELEX
+        )
+        Label.PhoneNumberTtyTdd -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_TTY_TDD
+        )
+        Label.PhoneNumberWorkMobile -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_WORK_MOBILE
+        )
+        Label.PhoneNumberWorkPager -> withCustomLabel(
+            resources, ContactColumn.Phones, Phone.TYPE_WORK_PAGER
+        )
+    }
+}

--- a/library/src/main/java/com/alexstyl/contactstore/ContactStore.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactStore.kt
@@ -56,7 +56,9 @@ public interface ContactStore {
             )
             return AndroidContactStore(
                 contentResolver = contentResolver,
-                newContactOperationsFactory = NewContactOperationsFactory(),
+                newContactOperationsFactory = NewContactOperationsFactory(
+                    resources
+                ),
                 existingContactOperationsFactory = ExistingContactOperationsFactory(
                     contentResolver,
                     resources,

--- a/library/src/main/java/com/alexstyl/contactstore/NewContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/NewContactOperationsFactory.kt
@@ -8,20 +8,23 @@ import android.provider.ContactsContract.CommonDataKinds.Organization as Organiz
 import android.provider.ContactsContract.CommonDataKinds.Phone as PhoneColumns
 import android.provider.ContactsContract.CommonDataKinds.Photo as PhotoColumns
 import android.provider.ContactsContract.CommonDataKinds.Relation as RelationColumns
+import android.provider.ContactsContract.CommonDataKinds.SipAddress as SipColumns
 import android.provider.ContactsContract.CommonDataKinds.StructuredName as NameColumns
 import android.provider.ContactsContract.CommonDataKinds.StructuredPostal as PostalColumns
 import android.provider.ContactsContract.CommonDataKinds.Website as WebsiteColumns
-import android.provider.ContactsContract.CommonDataKinds.SipAddress as SipColumns
 import android.content.ContentProviderOperation
 import android.content.ContentProviderOperation.newInsert
+import android.content.res.Resources
 import android.os.Build
-import android.provider.ContactsContract.CommonDataKinds.Contactables
 import android.provider.ContactsContract.Data
 import android.provider.ContactsContract.FullNameStyle
 import android.provider.ContactsContract.PhoneticNameStyle
 import android.provider.ContactsContract.RawContacts
 
-internal class NewContactOperationsFactory {
+
+internal class NewContactOperationsFactory(
+    private val resources: Resources
+) {
     fun addContactsOperation(contact: MutableContact): List<ContentProviderOperation> {
         return mutableListOf<ContentProviderOperation?>().apply {
             with(contact) {
@@ -67,7 +70,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, WebsiteColumns.CONTENT_ITEM_TYPE)
             .withValue(WebsiteColumns.URL, labeledValue.value.raw.toString())
-            .withWebsiteLabel(labeledValue.label)
+            .withWebAddressLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -77,7 +80,7 @@ internal class NewContactOperationsFactory {
             .withValue(Data.MIMETYPE, ImColumns.CONTENT_ITEM_TYPE)
             .withValue(ImColumns.DATA, labeledValue.value.raw)
             .withValue(ImColumns.CUSTOM_PROTOCOL, labeledValue.value.protocol)
-            .withImLabel(labeledValue.label)
+            .withImLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -86,7 +89,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, SipColumns.CONTENT_ITEM_TYPE)
             .withValue(SipColumns.SIP_ADDRESS, labeledValue.value.raw)
-            .withSipLabel(labeledValue.label)
+            .withSipLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -111,7 +114,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, PhoneColumns.CONTENT_ITEM_TYPE)
             .withValue(PhoneColumns.NUMBER, labeledValue.value.raw)
-            .withPhoneLabel(labeledValue.label)
+            .withPhoneLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -120,7 +123,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, EmailColumns.CONTENT_ITEM_TYPE)
             .withValue(EmailColumns.ADDRESS, labeledValue.value.raw)
-            .withMailLabel(labeledValue.label)
+            .withMailLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -129,7 +132,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, EventColumns.CONTENT_ITEM_TYPE)
             .withValue(EmailColumns.ADDRESS, sqlString(labeledValue.value))
-            .withEventLabel(labeledValue.label)
+            .withEventLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -144,7 +147,7 @@ internal class NewContactOperationsFactory {
             .withValue(PostalColumns.POSTCODE, labeledValue.value.postCode)
             .withValue(PostalColumns.REGION, labeledValue.value.region)
             .withValue(PostalColumns.STREET, labeledValue.value.street)
-            .withPostalAddressLabel(labeledValue.label)
+            .withPostalAddressLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -153,7 +156,7 @@ internal class NewContactOperationsFactory {
             .withValueBackReference(Data.RAW_CONTACT_ID, NEW_CONTACT_INDEX)
             .withValue(Data.MIMETYPE, RelationColumns.CONTENT_ITEM_TYPE)
             .withValue(RelationColumns.NAME, labeledValue.value.name)
-            .withRelationLabel(labeledValue.label)
+            .withRelationLabel(labeledValue.label, resources)
             .build()
     }
 
@@ -196,335 +199,7 @@ internal class NewContactOperationsFactory {
             .build()
     }
 
-    private fun ContentProviderOperation.Builder.withPhoneLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.PhoneNumberMobile -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_MOBILE
-            )
-            Label.LocationHome -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_HOME
-            )
-            Label.LocationWork -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_WORK
-            )
-            Label.PhoneNumberPager -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_PAGER
-            )
-            Label.PhoneNumberCar -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_CAR
-            )
-            Label.PhoneNumberFaxWork -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_FAX_WORK
-            )
-            Label.PhoneNumberFaxHome -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_FAX_HOME
-            )
-            Label.PhoneNumberCallback -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_CALLBACK
-            )
-            Label.PhoneNumberCompanyMain -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_COMPANY_MAIN
-            )
-            Label.PhoneNumberIsdn -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_ISDN
-            )
-            Label.Main -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_MAIN
-            )
-            Label.PhoneNumberOtherFax -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_OTHER_FAX
-            )
-            Label.PhoneNumberRadio -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_RADIO
-            )
-            Label.PhoneNumberTelex -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_TELEX
-            )
-            Label.PhoneNumberTtyTdd -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_TTY_TDD
-            )
-            Label.PhoneNumberWorkPager -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_WORK_PAGER
-            )
-            Label.PhoneNumberWorkMobile -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_WORK_MOBILE
-            )
-            Label.PhoneNumberAssistant -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_ASSISTANT
-            )
-            Label.PhoneNumberMms -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_MMS
-            )
-            Label.Other -> withValue(
-                Contactables.TYPE,
-                PhoneColumns.TYPE_OTHER
-            )
-            is Label.Custom -> {
-                withValue(
-                    Contactables.TYPE,
-                    Contactables.TYPE_CUSTOM
-                )
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsuported Phone label $label")
-        }
-    }
-
-    private fun ContentProviderOperation.Builder.withMailLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.LocationHome -> withValue(
-                Contactables.TYPE,
-                EmailColumns.TYPE_HOME
-            )
-            Label.LocationWork -> withValue(
-                Contactables.TYPE,
-                EmailColumns.TYPE_WORK
-            )
-            Label.Other -> withValue(
-                Contactables.TYPE,
-                EmailColumns.TYPE_OTHER
-            )
-            Label.PhoneNumberMobile -> withValue(
-                Contactables.TYPE,
-                EmailColumns.TYPE_MOBILE
-            )
-            is Label.Custom -> {
-                withValue(
-                    Contactables.TYPE,
-                    Contactables.TYPE_CUSTOM
-                )
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsupported Mail Label $label")
-        }
-    }
-
-    private fun ContentProviderOperation.Builder.withWebsiteLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.WebsiteBlog -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_BLOG)
-            Label.WebsiteFtp -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_FTP)
-            Label.LocationHome -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_HOME)
-            Label.WebsiteHomePage -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_HOMEPAGE)
-            Label.Other -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_OTHER)
-            Label.LocationWork -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_WORK)
-            Label.WebsiteProfile -> withValue(Contactables.TYPE, WebsiteColumns.TYPE_PROFILE)
-            is Label.Custom -> {
-                withValue(Contactables.TYPE, Contactables.TYPE_CUSTOM)
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsupported Website Label $label")
-        }
-    }
-
-
-    private fun ContentProviderOperation.Builder.withPostalAddressLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.LocationHome -> withValue(
-                Contactables.TYPE,
-                PostalColumns.TYPE_HOME
-            )
-            Label.LocationWork -> withValue(
-                Contactables.TYPE,
-                PostalColumns.TYPE_WORK
-            )
-            Label.Other -> withValue(
-                Contactables.TYPE,
-                PostalColumns.TYPE_OTHER
-            )
-            is Label.Custom -> {
-                withValue(
-                    Contactables.TYPE,
-                    Contactables.TYPE_CUSTOM
-                )
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsupported Postal Label $label")
-        }
-    }
-
-    private fun ContentProviderOperation.Builder.withImLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.LocationHome -> withValue(
-                Contactables.TYPE,
-                ImColumns.TYPE_HOME
-            )
-            Label.LocationWork -> withValue(
-                Contactables.TYPE,
-                ImColumns.TYPE_WORK
-            )
-            Label.Other -> withValue(
-                Contactables.TYPE,
-                ImColumns.TYPE_OTHER
-            )
-            is Label.Custom -> {
-                withValue(
-                    Contactables.TYPE,
-                    Contactables.TYPE_CUSTOM
-                )
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsupported Im Label $label")
-        }
-    }
-    private fun ContentProviderOperation.Builder.withEventLabel(
-        label: Label
-    ): ContentProviderOperation.Builder {
-        return when (label) {
-            Label.DateAnniversary -> withValue(
-                Contactables.TYPE,
-                EventColumns.TYPE_ANNIVERSARY
-            )
-            Label.DateBirthday -> withValue(
-                Contactables.TYPE,
-                EventColumns.TYPE_BIRTHDAY
-            )
-            Label.Other -> withValue(
-                Contactables.TYPE,
-                EventColumns.TYPE_OTHER
-            )
-            is Label.Custom -> {
-                withValue(
-                    Contactables.TYPE,
-                    Contactables.TYPE_CUSTOM
-                )
-                    .withValue(Contactables.LABEL, label.label)
-            }
-            else -> error("Unsupported Event Label $label")
-        }
-    }
-
     private companion object {
         const val NEW_CONTACT_INDEX = 0
-    }
-}
-
-internal fun ContentProviderOperation.Builder.withRelationLabel(
-    label: Label
-): ContentProviderOperation.Builder {
-    return when (label) {
-        Label.PhoneNumberAssistant -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_ASSISTANT
-        )
-        Label.RelationBrother -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_BROTHER
-        )
-        Label.RelationDomesticPartner -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_DOMESTIC_PARTNER
-        )
-        Label.RelationChild -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_CHILD
-        )
-        Label.RelationFather -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_FATHER
-        )
-        Label.RelationMother -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_MOTHER
-        )
-        Label.RelationManager -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_MANAGER
-        )
-        Label.RelationFriend -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_FRIEND
-        )
-        Label.RelationParent -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_PARENT
-        )
-        Label.RelationPartner -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_PARTNER
-        )
-        Label.RelationReferredBy -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_REFERRED_BY
-        )
-        Label.RelationSister -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_SISTER
-        )
-        Label.RelationSpouse -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_SPOUSE
-        )
-        Label.RelationRelative -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_RELATIVE
-        )
-        Label.Other -> withValue(
-            Contactables.TYPE,
-            RelationColumns.TYPE_CHILD
-        )
-        is Label.Custom -> {
-            withValue(
-                Contactables.TYPE,
-                Contactables.TYPE_CUSTOM
-            )
-                .withValue(Contactables.LABEL, label.label)
-        }
-        else -> error("Unsupported Postal Label $label")
-    }
-}
-
-internal fun ContentProviderOperation.Builder.withSipLabel(
-    label: Label
-): ContentProviderOperation.Builder {
-    return when (label) {
-        Label.LocationHome -> withValue(
-            Contactables.TYPE,
-            SipColumns.TYPE_HOME
-        )
-        Label.Other -> withValue(
-            Contactables.TYPE,
-            SipColumns.TYPE_OTHER
-        )
-        Label.LocationWork -> withValue(
-            Contactables.TYPE,
-            SipColumns.TYPE_WORK
-        )
-        is Label.Custom -> {
-            withValue(
-                Contactables.TYPE,
-                Contactables.TYPE_CUSTOM
-            )
-                .withValue(Contactables.LABEL, label.label)
-        }
-        else -> error("Unsupported Im Label $label")
     }
 }


### PR DESCRIPTION
This PR allows consumers to use any kind of `Label` they like in any `LabeledValue`.

Before this PR, creating a `LabeledValue(WebAddress("www.web.com"), label = Label.Main)` would throw an exception when trying to store or update a contact with this address. This was due to the fact that AOSP defines specific types for each ContactContract item.

After this PR, consumers of the API can mix and match any `LabeledValue` with any `Label` they like. The `Label` used will be resolved using the string resources provided by Android. In the previous example, the website will stored with the custom label of "Κύριο" if the local is set to Greek.

Addresses: https://github.com/alexstyl/contactstore/issues/1