### PR TITLE
Return lookupKey when fetching from TestContactStore

### DIFF
--- a/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
+++ b/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
@@ -111,6 +111,7 @@ public class TestContactStore(
                         StoredContact(
                             contactId = current.size.toLong(),
                             isStarred = contact.isStarred,
+                            lookupKey = contact.lookupKey,
                             prefix = contact.takeIfContains(ContactColumn.Names) { contact.prefix }
                                 .orEmpty(),
                             firstName = contact.takeIfContains(ContactColumn.Names) { contact.firstName }
@@ -335,7 +336,7 @@ public class TestContactStore(
             PartialContact(
                 displayName = displayName(it),
                 contactId = it.contactId,
-                lookupKey = null,
+                lookupKey = it.lookupKey,
                 columns = columnsToFetch,
                 isStarred = it.isStarred,
 

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
@@ -1,6 +1,7 @@
 package com.alexstyl.contactstore.test
 
 import android.net.Uri
+import com.alexstyl.contactstore.Contact
 import com.alexstyl.contactstore.ContactColumn
 import com.alexstyl.contactstore.ExperimentalContactStoreApi
 import com.alexstyl.contactstore.GroupMembership
@@ -10,6 +11,7 @@ import com.alexstyl.contactstore.LabeledValue
 import com.alexstyl.contactstore.MailAddress
 import com.alexstyl.contactstore.Note
 import com.alexstyl.contactstore.PartialContact
+import com.alexstyl.contactstore.PhoneNumber
 import com.alexstyl.contactstore.PostalAddress
 import com.alexstyl.contactstore.WebAddress
 import kotlinx.coroutines.runBlocking
@@ -31,23 +33,13 @@ internal class ColumnTestContactStoreTest {
 
         val actual = store.fetchContacts().blockingGet()
 
-        assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
-                columns = emptyList(),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
-            )
-        )
+        assertThat(actual).containsOnly(paoloMelendez())
     }
 
     @Test
     fun `fetches names from snapshot`(): Unit = runBlocking {
         val store = TestContactStore(
-            contactsSnapshot = listOf(
-                SnapshotFixtures.PAOLO_MELENDEZ
-            )
+            contactsSnapshot = listOf(SnapshotFixtures.PAOLO_MELENDEZ)
         )
 
         val actual = store.fetchContacts(
@@ -55,17 +47,13 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Names),
                 prefix = "Prefix",
-                firstName = "Paolo",
-                middleName = "Mid",
-                lastName = "Melendez",
                 suffix = "Suffix",
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
+                lastName = "Melendez",
+                middleName = "Mid",
+                firstName = "Paolo",
             )
         )
     }
@@ -83,13 +71,9 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Phones),
                 phones = ContactFixtures.PAOLO_MELENDEZ.phones,
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -107,15 +91,11 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Mails),
                 mails = listOf(
                     LabeledValue(MailAddress("hi@mail.com"), Label.LocationHome)
                 ),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -133,14 +113,10 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Organization),
                 organization = "Organization",
                 jobTitle = "Job Title",
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -158,13 +134,9 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Image),
                 imageData = ImageData("imagedata".toByteArray()),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -182,13 +154,9 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Note),
                 note = Note("note"),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -206,15 +174,11 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.PostalAddresses),
                 postalAddresses = listOf(
                     LabeledValue(PostalAddress("SomeStreet 55"), Label.LocationHome)
                 ),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -232,13 +196,9 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.Nickname),
                 nickname = "Nickname",
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -256,15 +216,11 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.WebAddresses),
                 webAddresses = listOf(
                     LabeledValue(WebAddress(Uri.parse("www.web.com")), Label.WebsiteHomePage)
                 ),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -282,16 +238,54 @@ internal class ColumnTestContactStoreTest {
         ).blockingGet()
 
         assertThat(actual).containsOnly(
-            PartialContact(
-                contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
-                displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
-                isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            paoloMelendez(
                 columns = listOf(ContactColumn.GroupMemberships),
                 groups = listOf(
                     GroupMembership(groupId = 10)
                 ),
-                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
+        )
+    }
+
+    private fun paoloMelendez(
+        columns: List<ContactColumn> = emptyList(),
+        prefix: String = "",
+        suffix: String = "",
+        groups: List<GroupMembership> = emptyList(),
+        webAddresses: List<LabeledValue<WebAddress>> = emptyList(),
+        nickname: String = "",
+        postalAddresses: List<LabeledValue<PostalAddress>> = emptyList(),
+        lastName: String = "",
+        middleName: String = "",
+        firstName: String = "",
+        note: Note? = null,
+        organization: String = "",
+        jobTitle: String = "",
+        imageData: ImageData? = null,
+        phones: List<LabeledValue<PhoneNumber>> = emptyList(),
+        mails: List<LabeledValue<MailAddress>> = emptyList(),
+    ): Contact {
+        return PartialContact(
+            imageData = imageData,
+            nickname = nickname,
+            groups = groups,
+            postalAddresses = postalAddresses,
+            webAddresses = webAddresses,
+            note = note,
+            columns = columns,
+            organization = organization,
+            jobTitle = jobTitle,
+            mails = mails,
+            phones = phones,
+            contactId = ContactFixtures.PAOLO_MELENDEZ.contactId,
+            displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
+            isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
+            prefix = prefix,
+            suffix = suffix,
+            middleName = middleName,
+            firstName = firstName,
+            lastName = lastName,
+            lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
         )
     }
 }

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ColumnTestContactStoreTest.kt
@@ -12,9 +12,7 @@ import com.alexstyl.contactstore.Note
 import com.alexstyl.contactstore.PartialContact
 import com.alexstyl.contactstore.PostalAddress
 import com.alexstyl.contactstore.WebAddress
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,7 +37,7 @@ internal class ColumnTestContactStoreTest {
                 displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = emptyList(),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -67,7 +65,7 @@ internal class ColumnTestContactStoreTest {
                 middleName = "Mid",
                 lastName = "Melendez",
                 suffix = "Suffix",
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -91,7 +89,7 @@ internal class ColumnTestContactStoreTest {
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = listOf(ContactColumn.Phones),
                 phones = ContactFixtures.PAOLO_MELENDEZ.phones,
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -117,7 +115,7 @@ internal class ColumnTestContactStoreTest {
                 mails = listOf(
                     LabeledValue(MailAddress("hi@mail.com"), Label.LocationHome)
                 ),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -142,7 +140,7 @@ internal class ColumnTestContactStoreTest {
                 columns = listOf(ContactColumn.Organization),
                 organization = "Organization",
                 jobTitle = "Job Title",
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -166,7 +164,7 @@ internal class ColumnTestContactStoreTest {
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = listOf(ContactColumn.Image),
                 imageData = ImageData("imagedata".toByteArray()),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -190,7 +188,7 @@ internal class ColumnTestContactStoreTest {
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = listOf(ContactColumn.Note),
                 note = Note("note"),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -216,7 +214,7 @@ internal class ColumnTestContactStoreTest {
                 postalAddresses = listOf(
                     LabeledValue(PostalAddress("SomeStreet 55"), Label.LocationHome)
                 ),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -240,7 +238,7 @@ internal class ColumnTestContactStoreTest {
                 isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
                 columns = listOf(ContactColumn.Nickname),
                 nickname = "Nickname",
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -266,7 +264,7 @@ internal class ColumnTestContactStoreTest {
                 webAddresses = listOf(
                     LabeledValue(WebAddress(Uri.parse("www.web.com")), Label.WebsiteHomePage)
                 ),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }
@@ -292,7 +290,7 @@ internal class ColumnTestContactStoreTest {
                 groups = listOf(
                     GroupMembership(groupId = 10)
                 ),
-                lookupKey = null,
+                lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
             )
         )
     }

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ContactFixtures.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ContactFixtures.kt
@@ -6,6 +6,7 @@ import com.alexstyl.contactstore.GroupMembership
 import com.alexstyl.contactstore.ImageData
 import com.alexstyl.contactstore.Label
 import com.alexstyl.contactstore.LabeledValue
+import com.alexstyl.contactstore.LookupKey
 import com.alexstyl.contactstore.MailAddress
 import com.alexstyl.contactstore.Note
 import com.alexstyl.contactstore.PartialContact
@@ -17,6 +18,7 @@ import com.alexstyl.contactstore.allContactColumns
 internal object ContactFixtures {
     val PAOLO_MELENDEZ = PartialContact(
         contactId = 0L,
+        lookupKey = LookupKey("test-lookup-paolo"),
         displayName = "Prefix Paolo Mid Melendez, Suffix",
         columns = allContactColumns(),
         isStarred = false,
@@ -46,6 +48,5 @@ internal object ContactFixtures {
         suffix = "Suffix",
         nickname = "Nickname",
         groups = listOf(GroupMembership(groupId = 10)),
-        lookupKey = null,
     )
 }

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/ExecuteTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/ExecuteTestContactStoreTest.kt
@@ -69,7 +69,7 @@ internal class ExecuteTestContactStoreTest {
                 displayName = "Prefix Peter Mid Melendez, Suffix",
                 isStarred = false,
                 columns = emptyList(),
-                lookupKey = null,
+                lookupKey = SNAPSHOT_PAOLO.lookupKey,
             ),
             kimClay()
         )

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
@@ -85,7 +85,7 @@ internal class PredicateTestContactStoreTest {
             displayName = ContactFixtures.PAOLO_MELENDEZ.displayName,
             isStarred = ContactFixtures.PAOLO_MELENDEZ.isStarred,
             columns = emptyList(),
-            lookupKey = null,
+            lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
         )
     }
 }

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/SnapshotFixtures.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/SnapshotFixtures.kt
@@ -1,16 +1,7 @@
 package com.alexstyl.contactstore.test
 
 import android.net.Uri
-import com.alexstyl.contactstore.EventDate
-import com.alexstyl.contactstore.GroupMembership
-import com.alexstyl.contactstore.ImageData
-import com.alexstyl.contactstore.Label
-import com.alexstyl.contactstore.LabeledValue
-import com.alexstyl.contactstore.MailAddress
-import com.alexstyl.contactstore.Note
-import com.alexstyl.contactstore.PhoneNumber
-import com.alexstyl.contactstore.PostalAddress
-import com.alexstyl.contactstore.WebAddress
+import com.alexstyl.contactstore.*
 
 internal object SnapshotFixtures {
     val KIM_CLAY = StoredContact(
@@ -21,9 +12,10 @@ internal object SnapshotFixtures {
     )
     val PAOLO_MELENDEZ = StoredContact(
         contactId = 0L,
+        lookupKey = ContactFixtures.PAOLO_MELENDEZ.lookupKey,
         isStarred = false,
-        firstName = "Paolo",
-        lastName = "Melendez",
+        firstName = ContactFixtures.PAOLO_MELENDEZ.firstName,
+        lastName = ContactFixtures.PAOLO_MELENDEZ.lastName,
         phones = listOf(
             LabeledValue(PhoneNumber("555-15"), Label.PhoneNumberMobile)
         ),


### PR DESCRIPTION
The TestContactStore was not taking into account the lookupKey. 

This PR includes the lookupKey of the Stored Contact when querying from the TestContactStore.

This PR resolves https://github.com/alexstyl/contactstore/issues/62