### PR TITLE
Rename NameLookup to ContactLookup

### DIFF
--- a/docs/lookup.md
+++ b/docs/lookup.md
@@ -3,14 +3,14 @@ contact by using a phone number and e-mail suggestion. Contact Store provides wa
 contacts stored on the device by providing a `ContactPredicate`
 when [reading contacts](./read_contacts.md)
 
-The following example uses the `ContactLookup` predicate to retrieve a contact with a given contact
+The following example uses the `ContactIdLookup` predicate to retrieve a contact with a given contact
 id:
 
 ```kotlin
 val store = ContactStore.newInstance(application)
 
 store.fetchContacts(
-    predicate = ContactLookup(contactId),
+    predicate = ContactIdLookup(contactId),
     columnsToFetch = allContactColumns()
 )
     .collect { contacts ->
@@ -26,7 +26,7 @@ store.fetchContacts(
 
 There are different kind of Predicates you can use:
 
-### ContactLookup
+### ContactIdLookup
 
 This predicate will return the contact with the passing contact id.
 
@@ -38,6 +38,6 @@ This predicate will return any contacts that contain part of the phone number pr
 
 This predicate will return any contacts that contain part of the mail address provided.
 
-### NameLookup
+### ContactLookup
 
-This predicate will return any contacts that contain part of the name.
+This predicate will return any contacts that contain the given string to any part of the contact. This is can be used to implement free-text search.

--- a/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
+++ b/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
@@ -278,7 +278,7 @@ public class TestContactStore(
                 val query = predicate.mailAddress
                 return contact.mails.any { it.value.raw.startsWith(query, ignoreCase = true) }
             }
-            is ContactPredicate.NameLookup -> matchesName(predicate, contact)
+            is ContactPredicate.ContactLookup -> matchesName(predicate, contact)
             is ContactPredicate.PhoneLookup -> matchesPhone(predicate, contact)
         }
     }
@@ -318,10 +318,10 @@ public class TestContactStore(
     }
 
     private fun matchesName(
-        predicate: ContactPredicate.NameLookup,
+        predicate: ContactPredicate.ContactLookup,
         contact: StoredContact
     ): Boolean {
-        val query = predicate.partOfName
+        val query = predicate.query
         val matchesName = contact.prefix.startsWith(query, ignoreCase = true)
                 || contact.firstName.startsWith(query, ignoreCase = true)
                 || contact.middleName.startsWith(query, ignoreCase = true)

--- a/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
+++ b/library-test/src/main/java/com/alexstyl/contactstore/test/TestContactStore.kt
@@ -273,7 +273,7 @@ public class TestContactStore(
     ): Boolean {
         if (predicate == null) return true
         return when (predicate) {
-            is ContactPredicate.ContactLookup -> matchesContact(predicate, contact)
+            is ContactPredicate.ContactIdLookup -> matchesContact(predicate, contact)
             is ContactPredicate.MailLookup -> {
                 val query = predicate.mailAddress
                 return contact.mails.any { it.value.raw.startsWith(query, ignoreCase = true) }
@@ -303,7 +303,7 @@ public class TestContactStore(
     }
 
     private fun matchesContact(
-        predicate: ContactPredicate.ContactLookup,
+        predicate: ContactPredicate.ContactIdLookup,
         contact: StoredContact
     ): Boolean {
         return predicate.contactId == contact.contactId

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
@@ -1,14 +1,11 @@
 package com.alexstyl.contactstore.test
 
-import com.alexstyl.contactstore.ContactPredicate.ContactLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
 import com.alexstyl.contactstore.ContactPredicate.NameLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
 import com.alexstyl.contactstore.ExperimentalContactStoreApi
-import com.alexstyl.contactstore.MailAddress
 import com.alexstyl.contactstore.PartialContact
-import com.alexstyl.contactstore.PhoneNumber
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -57,7 +54,7 @@ internal class PredicateTestContactStoreTest {
         )
 
         val actual = store.fetchContacts(
-            predicate = ContactLookup(contactId = 0L)
+            predicate = ContactIdLookup(contactId = 0L)
         ).blockingGet()
 
         assertThat(actual).containsOnly(CONTACT)

--- a/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
+++ b/library-test/src/test/java/com/alexstyl/contactstore/test/PredicateTestContactStoreTest.kt
@@ -2,7 +2,7 @@ package com.alexstyl.contactstore.test
 
 import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
-import com.alexstyl.contactstore.ContactPredicate.NameLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
 import com.alexstyl.contactstore.ExperimentalContactStoreApi
 import com.alexstyl.contactstore.PartialContact
@@ -39,7 +39,7 @@ internal class PredicateTestContactStoreTest {
         )
 
         val actual = store.fetchContacts(
-            predicate = NameLookup("Pao")
+            predicate = ContactLookup("Pao")
         ).blockingGet()
 
         assertThat(actual).containsOnly(CONTACT)

--- a/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreLookupTest.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreLookupTest.kt
@@ -1,7 +1,7 @@
 package com.alexstyl.contactstore
 
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
-import com.alexstyl.contactstore.ContactPredicate.NameLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -49,7 +49,7 @@ internal class ContactStoreLookupTest : ContactStoreTestBase() {
 
     @Test
     fun lookupByName() = runBlocking {
-        val actual = store.fetchContacts(NameLookup("Melendez")).blockingGet()
+        val actual = store.fetchContacts(ContactLookup("Melendez")).blockingGet()
         val expected = listOf(paoloMelendez())
 
         assertThat(actual, equalTo(expected))

--- a/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreTestBase.kt
+++ b/library/src/androidTest/java/com/alexstyl/contactstore/ContactStoreTestBase.kt
@@ -5,7 +5,7 @@ import android.provider.ContactsContract
 import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
-import com.alexstyl.contactstore.ContactPredicate.ContactLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.test.samePropertiesAs
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -24,7 +24,7 @@ internal abstract class ContactStoreTestBase {
     suspend fun assertContactUpdated(editedContact: MutableContact) {
         store.execute { update(editedContact) }
         val actual = store.fetchContacts(
-            predicate = ContactLookup(editedContact.contactId),
+            predicate = ContactIdLookup(editedContact.contactId),
             columnsToFetch = editedContact.columns
         ).blockingGet().first()
 
@@ -34,7 +34,7 @@ internal abstract class ContactStoreTestBase {
     suspend fun assertContactUpdatedNoId(expected: MutableContact) {
         store.execute { update(expected) }
         val actual = store.fetchContacts(
-            predicate = ContactLookup(expected.contactId),
+            predicate = ContactIdLookup(expected.contactId),
             columnsToFetch = expected.columns
         ).blockingGet().first()
 

--- a/library/src/main/java/com/alexstyl/contactstore/ContactPredicate.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactPredicate.kt
@@ -12,9 +12,11 @@ public sealed class ContactPredicate {
     public data class MailLookup(val mailAddress: String) : ContactPredicate()
 
     /**
-     * Performs a contact lookup by trying to match the given string against various parts of the contact name.
+     * Performs a contact lookup by trying to match the given string against various parts of the contact.
+     *
+     * This can be used for implementing free-text search.
      */
-    public data class NameLookup(val partOfName: String) : ContactPredicate()
+    public data class ContactLookup(val query: String) : ContactPredicate()
 
     /**
      * Performs a contact lookup by trying to find a contact with the given contact id.
@@ -26,8 +28,18 @@ public sealed class ContactPredicate {
             "ContactLookup was renamed to ContactIdLookup",
             ReplaceWith("ContactIdLookup(contactId)")
         )
+        @Suppress("FunctionName")
         public fun ContactLookup(contactId: Long): ContactPredicate {
             return ContactIdLookup(contactId)
+        }
+
+        @Deprecated(
+            "NameLookup was renamed to ContactLookup",
+            ReplaceWith("ContactLookup(partOfName)")
+        )
+        @Suppress("FunctionName")
+        public fun NameLookup(partOfName: String): ContactPredicate {
+            return ContactLookup(partOfName)
         }
     }
 }

--- a/library/src/main/java/com/alexstyl/contactstore/ContactPredicate.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactPredicate.kt
@@ -19,5 +19,15 @@ public sealed class ContactPredicate {
     /**
      * Performs a contact lookup by trying to find a contact with the given contact id.
      */
-    public data class ContactLookup(val contactId: Long) : ContactPredicate()
+    public data class ContactIdLookup(val contactId: Long) : ContactPredicate()
+
+    public companion object {
+        @Deprecated(
+            "ContactLookup was renamed to ContactIdLookup",
+            ReplaceWith("ContactIdLookup(contactId)")
+        )
+        public fun ContactLookup(contactId: Long): ContactPredicate {
+            return ContactIdLookup(contactId)
+        }
+    }
 }

--- a/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
@@ -41,7 +41,7 @@ import com.alexstyl.contactstore.ContactColumn.PostalAddresses
 import com.alexstyl.contactstore.ContactColumn.Relations
 import com.alexstyl.contactstore.ContactColumn.SipAddresses
 import com.alexstyl.contactstore.ContactColumn.WebAddresses
-import com.alexstyl.contactstore.ContactPredicate.ContactLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
 import com.alexstyl.contactstore.ContactPredicate.NameLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
@@ -86,7 +86,7 @@ internal class ContactQueries(
     ): Flow<List<PartialContact>> {
         return when (predicate) {
             null -> queryAllContacts(displayNameStyle)
-            is ContactLookup -> lookupContact(predicate.contactId, displayNameStyle)
+            is ContactIdLookup -> lookupContact(predicate.contactId, displayNameStyle)
             is MailLookup -> lookupFromMail(predicate.mailAddress, displayNameStyle)
             is PhoneLookup -> lookupFromPhone(predicate.phoneNumber, displayNameStyle)
             is NameLookup -> lookupFromName(predicate.partOfName, displayNameStyle)

--- a/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ContactQueries.kt
@@ -43,7 +43,7 @@ import com.alexstyl.contactstore.ContactColumn.SipAddresses
 import com.alexstyl.contactstore.ContactColumn.WebAddresses
 import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.ContactPredicate.MailLookup
-import com.alexstyl.contactstore.ContactPredicate.NameLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactLookup
 import com.alexstyl.contactstore.ContactPredicate.PhoneLookup
 import com.alexstyl.contactstore.utils.DateParser
 import com.alexstyl.contactstore.utils.mapEachRow
@@ -89,7 +89,7 @@ internal class ContactQueries(
             is ContactIdLookup -> lookupContact(predicate.contactId, displayNameStyle)
             is MailLookup -> lookupFromMail(predicate.mailAddress, displayNameStyle)
             is PhoneLookup -> lookupFromPhone(predicate.phoneNumber, displayNameStyle)
-            is NameLookup -> lookupFromName(predicate.partOfName, displayNameStyle)
+            is ContactLookup -> lookupFromName(predicate.query, displayNameStyle)
         }
     }
 

--- a/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
+++ b/library/src/main/java/com/alexstyl/contactstore/ExistingContactOperationsFactory.kt
@@ -47,7 +47,7 @@ internal class ExistingContactOperationsFactory(
 ) {
     suspend fun updateOperation(contact: MutableContact): List<ContentProviderOperation> {
         val existingContact = contactQueries.queryContacts(
-            predicate = ContactPredicate.ContactLookup(contact.contactId),
+            predicate = ContactPredicate.ContactIdLookup(contact.contactId),
             columnsToFetch = contact.columns,
             displayNameStyle = DisplayNameStyle.Primary
         ).first().firstOrNull() ?: return emptyList()

--- a/sample/src/main/java/com/alexstyl/contactstore/sample/ContactDetailsActivity.kt
+++ b/sample/src/main/java/com/alexstyl/contactstore/sample/ContactDetailsActivity.kt
@@ -40,7 +40,7 @@ import androidx.core.content.ContextCompat
 import coil.compose.rememberImagePainter
 import coil.transform.CircleCropTransformation
 import com.alexstyl.contactstore.Contact
-import com.alexstyl.contactstore.ContactPredicate.ContactLookup
+import com.alexstyl.contactstore.ContactPredicate.ContactIdLookup
 import com.alexstyl.contactstore.ContactStore
 import com.alexstyl.contactstore.allContactColumns
 import com.alexstyl.contactstore.getLocalizedString
@@ -63,7 +63,7 @@ class ContactDetailsActivity : ComponentActivity() {
             .getLong(EXTRA_CONTACT_ID)
 
         val contact = contactStore.fetchContacts(
-            predicate = ContactLookup(contactId),
+            predicate = ContactIdLookup(contactId),
             columnsToFetch = allContactColumns()
         ).blockingGet().firstOrNull()
         if (contact == null) {


### PR DESCRIPTION
The `Contact.CONTENT_FILTER_URI` seems to be returning all contacts that include the given string in any part of the contact instead of just its name. 

This PR renames the predicates to reflect that.

Fixes Issue https://github.com/alexstyl/contactstore/issues/67